### PR TITLE
Add `vscode-textmate` compliance/comparison suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "laravel/pint": "^1.18.1",
         "phpstan/phpstan": "^2.0",
         "phpstan/extension-installer": "^1.4.3",
-        "illuminate/support": "^11.30"
+        "illuminate/support": "^11.30",
+        "symfony/process": "^7.2"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,11 @@
             "Composer\\Config::disableProcessTimeout",
             "@php ./meta/update-sources.php"
         ],
-        "test": "@php -dmemory_limit=-1 vendor/bin/pest --enforce-time-limit --default-time-limit=1",
+        "test": "@php -dmemory_limit=-1 vendor/bin/pest --enforce-time-limit --default-time-limit=1 --exclude-group integration/vscode-textmate",
+        "test:full": "@php -dmemory_limit=-1 vendor/bin/pest --enforce-time-limit --default-time-limit=1",
+        "test:vscode": "@php -dmemory_limit=-1 vendor/bin/pest --enforce-time-limit --default-time-limit=1 --group integration/vscode-textmate --bail",
+        "test:grammars": "@php -dmemory_limit=-1 vendor/bin/pest --enforce-time-limit --default-time-limit=1 --group integration/grammars",
+        "test:themes": "@php -dmemory_limit=-1 vendor/bin/pest --enforce-time-limit --default-time-limit=1 --group integration/themes",
         "lint": "vendor/bin/phpstan"
     }
 }

--- a/tests/Fixtures/vscode-textmate-compliance.js
+++ b/tests/Fixtures/vscode-textmate-compliance.js
@@ -1,8 +1,11 @@
 const process = require('node:process');
 const fs = require('node:fs');
+const path = require('node:path');
+const oniguruma = require('vscode-oniguruma');
+const vsctm = require('vscode-textmate');
 
 const sample = process.argv[2];
-const grammar = process.argv[3];
+const scope = process.argv[3];
 const scopeMap = JSON.parse(process.argv[4]);
 
 function readFile(path) {
@@ -44,7 +47,7 @@ const registry = new vsctm.Registry({
 
 const tokens = []
 
-registry.loadGrammar(grammar).then(async grammar => {
+registry.loadGrammar(scope).then(async grammar => {
     const text = await readFile(sample);
     const lines = text.toString().split(/\r?\n/);
 
@@ -54,7 +57,7 @@ registry.loadGrammar(grammar).then(async grammar => {
         const lineTokens = grammar.tokenizeLine(line, ruleStack);
 
         tokens.push(
-            lineTokens.map(lineToken => ({
+            lineTokens.tokens.map(lineToken => ({
                 scopes: lineToken.scopes,
                 text: line.substring(lineToken.startIndex, lineToken.endIndex),
                 start: lineToken.startIndex,
@@ -64,4 +67,6 @@ registry.loadGrammar(grammar).then(async grammar => {
 
         ruleStack = lineTokens.ruleStack;
     }
+
+    console.log(JSON.stringify(tokens));
 })

--- a/tests/Fixtures/vscode-textmate-compliance.js
+++ b/tests/Fixtures/vscode-textmate-compliance.js
@@ -1,0 +1,67 @@
+const process = require('node:process');
+const fs = require('node:fs');
+
+const sample = process.argv[2];
+const grammar = process.argv[3];
+const scopeMap = JSON.parse(process.argv[4]);
+
+function readFile(path) {
+    return new Promise((resolve, reject) => {
+        fs.readFile(path, (error, data) =>
+            error ? reject(error) : resolve(data)
+        );
+    });
+}
+
+const wasmBin = fs.readFileSync(
+    path.join(__dirname, "../../node_modules/vscode-oniguruma/release/onig.wasm")
+).buffer;
+
+const vscodeOnigurumaLib = oniguruma.loadWASM(wasmBin).then(() => {
+    return {
+        createOnigScanner(patterns) {
+            return new oniguruma.OnigScanner(patterns);
+        },
+        createOnigString(s) {
+            return new oniguruma.OnigString(s);
+        },
+    };
+});
+
+const registry = new vsctm.Registry({
+    onigLib: vscodeOnigurumaLib,
+    loadGrammar: (scopeName) => {
+        if (! scopeMap[scopeName]) {
+            console.error(`Unknown scope name: ${scopeName}`);
+            process.exit(1);
+        }
+
+        return readFile(scopeMap[scopeName]).then(data => {
+            return vsctm.parseRawGrammar(data.toString(), scopeMap[scopeName]);
+        })
+    },
+});
+
+const tokens = []
+
+registry.loadGrammar(grammar).then(async grammar => {
+    const text = await readFile(sample);
+    const lines = text.toString().split(/\r?\n/);
+
+    let ruleStack = vsctm.INITIAL;
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const lineTokens = grammar.tokenizeLine(line, ruleStack);
+
+        tokens.push(
+            lineTokens.map(lineToken => ({
+                scopes: lineToken.scopes,
+                text: line.substring(lineToken.startIndex, lineToken.endIndex),
+                start: lineToken.startIndex,
+                end: lineToken.endIndex,
+            }))
+        )
+
+        ruleStack = lineTokens.ruleStack;
+    }
+})

--- a/tests/Integration/GrammarsTest.php
+++ b/tests/Integration/GrammarsTest.php
@@ -1,7 +1,8 @@
 <?php
 
-use Phiki\Grammar\GrammarRepository;
 use Phiki\Phiki;
+
+pest()->group('integration/grammars');
 
 describe('Grammars', function () {
     test('default grammars do not produce warnings or exceptions', function (string $grammar) {
@@ -11,34 +12,4 @@ describe('Grammars', function () {
     })
         ->with('grammars')
         ->throwsNoExceptions();
-});
-
-dataset('grammars', function () {
-    $repository = new GrammarRepository;
-    $grammars = array_filter($repository->getAllGrammarNames(), fn (string $grammar) => ! in_array($grammar, [
-        'astro',
-        'haxe',
-        'fluent',
-        'stylus',
-        'viml',
-        'sas',
-        'git-commit',
-        'hxml',
-        'groovy',
-        'make',
-        'shellsession',
-        // Act as includes, basically.
-        'html-derivative',
-        'cpp-macro',
-        'jinja-html',
-        // No sample file.
-        'git-rebase',
-        // Empty.
-        'txt',
-    ]));
-
-    sort($grammars, SORT_NATURAL);
-
-    // FIXME: These grammars have known issues and should be skipped.
-    return array_values($grammars);
 });

--- a/tests/Integration/VscodeTextmateTest.php
+++ b/tests/Integration/VscodeTextmateTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use Phiki\Phiki;
+
+pest()->group('integration/vscode-textmate');
+
+test('it produces the same tokens as vscode-textmate', function (string $grammar) {
+    $samplePath = __DIR__ . "/../../resources/samples/{$grammar}.sample";
+
+    $expected = vscodeTextmateTokenize($samplePath, $grammar);
+    $actual = (new Phiki)->codeToTokens(file_get_contents($samplePath), $grammar);
+
+    expect($actual)->toEqualCanonicalizing($expected);
+})
+    ->with('grammars');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,8 +1,11 @@
 <?php
 
 use Phiki\Environment\Environment;
+use Phiki\Grammar\DefaultGrammars;
 use Phiki\Grammar\ParsedGrammar;
+use Phiki\Token\Token;
 use Phiki\Tokenizer;
+use Symfony\Component\Process\Process;
 
 function tokenize(string $input, array $grammar): array
 {
@@ -12,4 +15,40 @@ function tokenize(string $input, array $grammar): array
     );
 
     return $tokenizer->tokenize($input);
+}
+
+function vscodeTextmateTokenize(string $samplePath, string $grammarName): array
+{
+    $process = new Process(
+        [
+            'node',
+            __DIR__ . '/Fixtures/vscode-textmate-compliance.js',
+            $samplePath,
+            $grammarName,
+            json_encode(collect(DefaultGrammars::SCOPES_TO_NAMES)
+                ->mapWithKeys(fn (string $name, string $scope) => [$scope => DefaultGrammars::NAMES_TO_PATHS[$name]])
+                ->all()),
+        ],
+    );
+
+    $process->run();
+
+    if (! $process->isSuccessful()) {
+        throw new RuntimeException($process->getErrorOutput());
+    }
+
+    $output = json_decode($process->getOutput(), true);
+
+    if (! is_array($output)) {
+        throw new RuntimeException('Invalid output from process');
+    }
+
+    return collect($output)
+        ->map(fn (array $token) => new Token(
+            scopes: $token['scopes'],
+            text: $token['text'],
+            start: $token['start'],
+            end: $token['end'],
+        ))
+        ->all();
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,7 @@
 
 use Phiki\Environment\Environment;
 use Phiki\Grammar\DefaultGrammars;
+use Phiki\Grammar\GrammarRepository;
 use Phiki\Grammar\ParsedGrammar;
 use Phiki\Token\Token;
 use Phiki\Tokenizer;
@@ -24,7 +25,7 @@ function vscodeTextmateTokenize(string $samplePath, string $grammarName): array
             'node',
             __DIR__ . '/Fixtures/vscode-textmate-compliance.js',
             $samplePath,
-            $grammarName,
+            array_flip(DefaultGrammars::SCOPES_TO_NAMES)[$grammarName],
             json_encode(collect(DefaultGrammars::SCOPES_TO_NAMES)
                 ->mapWithKeys(fn (string $name, string $scope) => [$scope => DefaultGrammars::NAMES_TO_PATHS[$name]])
                 ->all()),
@@ -34,21 +35,55 @@ function vscodeTextmateTokenize(string $samplePath, string $grammarName): array
     $process->run();
 
     if (! $process->isSuccessful()) {
-        throw new RuntimeException($process->getErrorOutput());
+        throw new RuntimeException($process->getErrorOutput() . ':' . PHP_EOL . $process->getOutput());
     }
 
     $output = json_decode($process->getOutput(), true);
 
     if (! is_array($output)) {
-        throw new RuntimeException('Invalid output from process');
+        throw new RuntimeException('Invalid output from process:' . PHP_EOL . $process->getOutput());
     }
-
-    return collect($output)
-        ->map(fn (array $token) => new Token(
-            scopes: $token['scopes'],
-            text: $token['text'],
-            start: $token['start'],
-            end: $token['end'],
-        ))
-        ->all();
+    
+    return array_map(
+        fn (array $lineTokens) => array_map(
+            fn (array $token) => new Token(
+                scopes: $token['scopes'],
+                text: $token['text'],
+                start: $token['start'],
+                end: $token['end'],
+            ),
+            $lineTokens
+        ),
+        $output
+    );
 }
+
+dataset('grammars', function () {
+    $repository = new GrammarRepository;
+    $grammars = array_filter($repository->getAllGrammarNames(), fn(string $grammar) => ! in_array($grammar, [
+        'astro',
+        'haxe',
+        'fluent',
+        'stylus',
+        'viml',
+        'sas',
+        'git-commit',
+        'hxml',
+        'groovy',
+        'make',
+        'shellsession',
+        // Act as includes, basically.
+        'html-derivative',
+        'cpp-macro',
+        'jinja-html',
+        // No sample file.
+        'git-rebase',
+        // Empty.
+        'txt',
+    ]));
+
+    sort($grammars, SORT_NATURAL);
+
+    // FIXME: These grammars have known issues and should be skipped.
+    return array_values($grammars);
+});


### PR DESCRIPTION
Closes #61.

Adds a new `integration/vscode-textmate` group that compares Phiki's generated tokens to that of `vscode-textmate`.

The goal now is to go through and look for any inconsistencies and hopefully squash some bugs.

(It'd be really nice to get that list of excluded grammars gone too)