### PR TITLE
Use configurable extension interface

### DIFF
--- a/src/CommonMark/PhikiExtension.php
+++ b/src/CommonMark/PhikiExtension.php
@@ -17,7 +17,7 @@ class PhikiExtension implements ConfigurableExtensionInterface
      * @param  bool  $withWrapper  Wrap the generated HTML in an additional `<div>` so that it can be styled with CSS. Useful for avoiding overflow issues.
      */
     public function __construct(
-        private string|array|Theme $theme,
+        private string|array|Theme $theme = Theme::Nord,
         private Phiki $phiki = new Phiki,
         private bool $withGutter = false,
         private bool $withWrapper = false,

--- a/src/CommonMark/PhikiExtension.php
+++ b/src/CommonMark/PhikiExtension.php
@@ -4,11 +4,13 @@ namespace Phiki\CommonMark;
 
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
-use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\Extension\ConfigurableExtensionInterface;
 use Phiki\Phiki;
 use Phiki\Theme\Theme;
+use League\Config\ConfigurationBuilderInterface;
+use Nette\Schema\Expect;
 
-class PhikiExtension implements ExtensionInterface
+class PhikiExtension implements ConfigurableExtensionInterface
 {
     /**
      * @param  bool  $withGutter  Include a gutter in the generated HTML. The gutter typically contains line numbers and helps provide context for the code.
@@ -21,9 +23,27 @@ class PhikiExtension implements ExtensionInterface
         private bool $withWrapper = false,
     ) {}
 
+    public function configureSchema(ConfigurationBuilderInterface $builder): void
+    {
+        $builder->addSchema('phiki', Expect::structure([
+            'theme' => Expect::mixed()->default($this->theme),
+            'with_gutter' => Expect::bool()->default($this->withGutter),
+            'with_wrapper' => Expect::bool()->default($this->withWrapper),
+        ]));
+    }
+
     public function register(EnvironmentBuilderInterface $environment): void
     {
-        $environment
-            ->addRenderer(FencedCode::class, new CodeBlockRenderer($this->theme, $this->phiki, $this->withGutter, $this->withWrapper), 10);
+        $config = $environment->getConfiguration();
+
+        $theme = $config->get('phiki/theme');
+        $withGutter = $config->get('phiki/with_gutter');
+        $withWrapper = $config->get('phiki/with_wrapper');
+
+        $environment->addRenderer(
+            FencedCode::class,
+            new CodeBlockRenderer($theme, $this->phiki, $withGutter, $withWrapper),
+            10,
+        );
     }
 }

--- a/tests/.pest/snapshots/Unit/CommonMark/PhikiExtensionTest/it_can_be_configured_using_environment_config_array.snap
+++ b/tests/.pest/snapshots/Unit/CommonMark/PhikiExtensionTest/it_can_be_configured_using_environment_config_array.snap
@@ -1,0 +1,2 @@
+<pre class="phiki language-php github-light" data-language="php" style="background-color: #fff;color: #24292e;"><code><span class="line"><span class="token" style="color: #d73a49;">class</span><span class="token"> </span><span class="token" style="color: #6f42c1;">A</span><span class="token"> </span><span class="token">{</span><span class="token">}</span><span class="token">
+</span></span></code></pre>

--- a/tests/Unit/CommonMark/PhikiExtensionTest.php
+++ b/tests/Unit/CommonMark/PhikiExtensionTest.php
@@ -4,45 +4,67 @@ use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\MarkdownConverter;
 use Phiki\CommonMark\PhikiExtension;
+use Phiki\Theme\Theme;
 
-describe('CommonMark > Extension', function () {
-    it('registers renderers', function () {
-        $environment = new Environment;
+it('registers renderers', function () {
+    $environment = new Environment;
 
-        $environment
-            ->addExtension(new CommonMarkCoreExtension)
-            ->addExtension(new PhikiExtension('github-dark'));
+    $environment
+        ->addExtension(new CommonMarkCoreExtension)
+        ->addExtension(new PhikiExtension('github-dark'));
 
-        $markdown = new MarkdownConverter($environment);
-        $generated = $markdown->convert(<<<'MD'
-        ```php
-        class A {}
-        ```
-        MD)->getContent();
+    $markdown = new MarkdownConverter($environment);
+    $generated = $markdown->convert(<<<'MD'
+    ```php
+    class A {}
+    ```
+    MD)->getContent();
 
-        expect($generated)
-            ->toContain('phiki')
-            ->toContain('github-dark')
-            ->toContain('<span class="token" style="color: #b392f0;">A</span>');
-    });
+    expect($generated)
+        ->toContain('phiki')
+        ->toContain('github-dark')
+        ->toContain('<span class="token" style="color: #b392f0;">A</span>');
+});
 
-    it('auto detects grammar if not provided', function () {
-        $environment = new Environment;
+it('auto detects grammar if not provided', function () {
+    $environment = new Environment;
 
-        $environment
-            ->addExtension(new CommonMarkCoreExtension)
-            ->addExtension(new PhikiExtension('github-dark'));
+    $environment
+        ->addExtension(new CommonMarkCoreExtension)
+        ->addExtension(new PhikiExtension('github-dark'));
 
-        $markdown = new MarkdownConverter($environment);
-        $generated = $markdown->convert(<<<'MD'
-        ```
-        <?php
+    $markdown = new MarkdownConverter($environment);
+    $generated = $markdown->convert(<<<'MD'
+    ```
+    <?php
 
-        echo "Hello, world!";
-        ```
-        MD)->getContent();
+    echo "Hello, world!";
+    ```
+    MD)->getContent();
 
-        expect($generated)
-            ->toContain('data-language="php"');
-    });
+    expect($generated)
+        ->toContain('data-language="php"');
+});
+
+it('can be configured using environment config array', function () {
+    $environment = new Environment([
+        'phiki' => [
+            'theme' => Theme::GithubLight,
+            'with_gutter' => false,
+            'with_wrapper' => false,
+        ],
+    ]);
+
+    $environment
+        ->addExtension(new CommonMarkCoreExtension)
+        ->addExtension(new PhikiExtension);
+    $markdown = new MarkdownConverter($environment);
+
+    $generated = $markdown->convert(<<<'MD'
+    ```php
+    class A {}
+    ```
+    MD)->getContent();
+
+    expect($generated)->toMatchSnapshot();
 });


### PR DESCRIPTION
This pull request updates the included CommonMark extension to use the ConfigurableExtensionInterface as documented here: https://commonmark.thephpleague.com/2.7/customization/configuration/.

This allows the user to pass a single config when setting up the CommonMark environment which is useful when dynamically adding extensions.

For example:

```php
$config = [
    'table_of_contents' => [
        'html_class' => 'table-of-contents',
        'position' => 'top',
        'style' => 'bullet',
        'min_heading_level' => 1,
        'max_heading_level' => 6,
        'normalize' => 'relative',
        'placeholder' => null,
    ],
    'phiki' => [
        'theme' => \Phiki\Theme\Theme::NightOwl,
        'with_gutter' => false,
        'with_wrapper' => true
    ]
];

$extensions = [
    League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension::class,
    Phiki\CommonMark\PhikiExtension::class,
],

$environment = new Environment($config);

foreach ($extensions as $extension) {
    $environment->addExtension(new $extension);
}

$converter = new MarkdownConverter($environment);
echo $converter->convert('# Awesome!');
```


