### PR TITLE
Prevent infinite recursion

### DIFF
--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -28,6 +28,7 @@ class Tokenizer
     protected State $state;
 
     protected array $tokens = [];
+    protected array $activeCapturesStack = [];
 
     public function __construct(
         protected ParsedGrammar $grammar,
@@ -41,6 +42,7 @@ class Tokenizer
         $this->state->pushScopes(preg_split('/\s+/', $this->grammar->scopeName));
 
         $this->tokens = [];
+        $this->activeCapturesStack = [];
 
         $lines = preg_split("/\R/", $input);
 
@@ -478,6 +480,24 @@ class Tokenizer
 
     protected function captures(MatchedPattern $pattern, int $line, string $lineText): void
     {
+        $recursionKey = spl_object_id($pattern->pattern) . ':' . $this->state->getLinePosition();
+        if (isset($this->activeCapturesStack[$recursionKey])) {
+            // Minimal advance to break loop
+            $advanceLength = max(1, strlen($pattern->text())); 
+            $advanceTo = $this->state->getLinePosition() + $advanceLength;
+
+            $this->tokens[$line][] = new Token(
+                ['error.tokenizer.infinite.recursion', ...$this->state->getScopes()],
+                substr($lineText, $this->state->getLinePosition(), $advanceLength),
+                $this->state->getLinePosition(),
+                $advanceTo
+            );
+            $this->state->setLinePosition($advanceTo);
+            return; // Abort this captures call
+        }
+
+        $this->activeCapturesStack[$recursionKey] = true;
+
         if (! $pattern->pattern instanceof ContainsCapturesInterface) {
             throw new IndeterminateStateException('Patterns must implement '.ContainsCapturesInterface::class.' in order to process captures.');
         }

--- a/tests/Unit/TokenizerTest.php
+++ b/tests/Unit/TokenizerTest.php
@@ -613,3 +613,36 @@ describe('scopes', function () {
         ]);
     });
 });
+
+describe('infinite recursion protection', function () {
+    it('prevents infinite recursion for pathological patterns', function () {
+        $tokens = tokenize('foo', [
+            'scopeName' => 'source.test',
+            'patterns' => [
+                    [
+                        'name' => 'meta.recursive.test',
+                        'match' => '',
+                        'captures' => [
+                            '0' => [
+                                'patterns' => [
+                                    [
+                                        'match' => '',
+                                        'name' => 'meta.recursive.test',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'name' => 'meta.fallback.test',
+                        'match' => '.+',
+                    ],
+                ],
+            ]);
+        $flat = array_merge(...$tokens);
+        expect($flat)->not->toBeEmpty();
+        foreach ($flat as $token) {
+            expect($token->scopes)->toContain('error.tokenizer.infinite.recursion');
+        }
+    });
+});


### PR DESCRIPTION
This commit prevents the tokenizer from entering an infinite loop when a pattern (especially one with captures and subpatterns) recursively matches itself at the same position.

I've had an infinite loop with this cpp code (actually this is code which does not compile and is meant for demo purposes).

```cpp
auto rng=std::vector<int>{1,2,3} | std::ranges::view::filter([](int i){ return 0==i%2; });
// DOES NOT COMPILE
```

For me, the snippets mentioned in #52 and #53 didn’t cause any infinite loops, so I’m unsure if my fix only addresses my specific issue or if this PR is generally useful. Unfortunately, I don't have other snippets that produce infinite loops to further test my implementation 🥲