### PR TITLE
[2.x] Improve infinite loop prevention

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,10 @@
             "node meta/update-grammars-and-themes.js",
             "php meta/generate-vscode-token-dumps.php"
         ],
+        "update-grammars-and-themes:only": [
+            "Composer\\Config::disableProcessTimeout",
+            "node meta/update-grammars-and-themes.js"
+        ],
         "test": "@php -dmemory_limit=-1 vendor/bin/pest --enforce-time-limit --default-time-limit=1",
         "lint": "@php vendor/bin/phpstan"
     }

--- a/meta/sample/index.php
+++ b/meta/sample/index.php
@@ -1,4 +1,7 @@
 <?php
+
+set_time_limit(2);
+
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 use Phiki\Grammar\Grammar;

--- a/meta/update-grammars-and-themes.js
+++ b/meta/update-grammars-and-themes.js
@@ -9,7 +9,7 @@ console.log("Updating grammars...");
 const cases = {}
 const aliases = {}
 const scopeNames = {}
-const exclusions = ["source.bicep", "source.svelte", "text.xml"];
+const exclusions = ["source.bicep", "text.xml"];
 
 grammars.forEach(grammar => {
     if (grammar.injectTo) {

--- a/src/Contracts/PatternInterface.php
+++ b/src/Contracts/PatternInterface.php
@@ -19,4 +19,9 @@ interface PatternInterface
      * @return array<array{ 0: PatternInterface, 1: string }>
      */
     public function compile(ParsedGrammar $grammar, GrammarRepositoryInterface $grammars, bool $allowA, bool $allowG): array;
+
+    /**
+     * Get the ID of the pattern.
+     */
+    public function getId(): int;
 }

--- a/src/Grammar/BeginEndPattern.php
+++ b/src/Grammar/BeginEndPattern.php
@@ -11,6 +11,7 @@ use Phiki\Support\Str;
 class BeginEndPattern implements PatternInterface, HasContentNameInterface
 {
     public function __construct(
+        public int $id,
         public Regex $begin,
         public Regex $end,
         public ?string $name,
@@ -63,6 +64,7 @@ class BeginEndPattern implements PatternInterface, HasContentNameInterface
     public function createEndPattern(MatchedPattern $matched): EndPattern
     {
         return new EndPattern(
+            id: $this->id,
             begin: $matched,
             end: $this->end,
             name: $this->name,
@@ -72,5 +74,10 @@ class BeginEndPattern implements PatternInterface, HasContentNameInterface
             patterns: $this->patterns,
             injection: $this->injection,
         );
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
     }
 }

--- a/src/Grammar/BeginWhilePattern.php
+++ b/src/Grammar/BeginWhilePattern.php
@@ -11,6 +11,7 @@ use Phiki\Support\Str;
 class BeginWhilePattern implements PatternInterface, HasContentNameInterface
 {
     public function __construct(
+        public int $id,
         public Regex $begin,
         public Regex $while,
         public ?string $name,
@@ -60,6 +61,7 @@ class BeginWhilePattern implements PatternInterface, HasContentNameInterface
     public function createWhilePattern(MatchedPattern $matched): WhilePattern
     {
         return new WhilePattern(
+            $this->id,
             $matched,
             $this->while,
             $this->name,
@@ -69,5 +71,10 @@ class BeginWhilePattern implements PatternInterface, HasContentNameInterface
             $this->patterns,
             $this->injection
         );
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
     }
 }

--- a/src/Grammar/Capture.php
+++ b/src/Grammar/Capture.php
@@ -9,14 +9,15 @@ use Phiki\Support\Str;
 class Capture implements PatternInterface
 {
     public function __construct(
+        public int $id,
         public string $index,
         public ?string $name,
-        public array $patterns = [],
+        public CollectionPattern $pattern,
     ) {}
 
     public function retokenizeCapturedWithRule(): bool
     {
-        return count($this->patterns) > 0;
+        return count($this->pattern->patterns) > 0;
     }
 
     public function getScopeName(array $captures): ?string
@@ -30,12 +31,11 @@ class Capture implements PatternInterface
 
     public function compile(ParsedGrammar $grammar, GrammarRepositoryInterface $grammars, bool $allowA, bool $allowG): array
     {
-        $compiled = [];
+        return $this->pattern->compile($grammar, $grammars, $allowA, $allowG);
+    }
 
-        foreach ($this->patterns as $pattern) {
-            $compiled = array_merge($compiled, $pattern->compile($grammar, $grammars, $allowA, $allowG));
-        }
-
-        return $compiled;
+    public function getId(): int
+    {
+        return $this->id;
     }
 }

--- a/src/Grammar/CollectionPattern.php
+++ b/src/Grammar/CollectionPattern.php
@@ -11,6 +11,7 @@ class CollectionPattern implements PatternInterface
      * @param  PatternInterface[]  $patterns
      */
     public function __construct(
+        public int $id,
         public array $patterns,
         public bool $injection = false,
     ) {}
@@ -34,5 +35,10 @@ class CollectionPattern implements PatternInterface
         }
 
         return $compiled;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
     }
 }

--- a/src/Grammar/EndPattern.php
+++ b/src/Grammar/EndPattern.php
@@ -10,6 +10,7 @@ use Phiki\Support\Str;
 class EndPattern implements PatternInterface
 {
     public function __construct(
+        public int $id,
         public MatchedPattern $begin,
         public Regex $end,
         public ?string $name,
@@ -50,5 +51,10 @@ class EndPattern implements PatternInterface
         }
 
         return $compiled;
-    }   
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
 }

--- a/src/Grammar/Grammar.php
+++ b/src/Grammar/Grammar.php
@@ -188,6 +188,7 @@ enum Grammar: string
     case SshConfig = 'ssh-config';
     case Stata = 'stata';
     case Stylus = 'stylus';
+    case Svelte = 'svelte';
     case Swift = 'swift';
     case SystemVerilog = 'system-verilog';
     case Systemd = 'systemd';
@@ -410,6 +411,7 @@ enum Grammar: string
             self::SshConfig => [],
             self::Stata => [],
             self::Stylus => ["styl"],
+            self::Svelte => [],
             self::Swift => [],
             self::SystemVerilog => [],
             self::Systemd => [],
@@ -636,6 +638,7 @@ enum Grammar: string
             self::SshConfig => 'source.ssh-config',
             self::Stata => 'source.stata',
             self::Stylus => 'source.stylus',
+            self::Svelte => 'source.svelte',
             self::Swift => 'source.swift',
             self::SystemVerilog => 'source.systemverilog',
             self::Systemd => 'source.systemd',

--- a/src/Grammar/IncludePattern.php
+++ b/src/Grammar/IncludePattern.php
@@ -9,6 +9,7 @@ use Phiki\Exceptions\UnrecognisedGrammarException;
 class IncludePattern implements PatternInterface
 {
     public function __construct(
+        public int $id,
         public ?string $reference,
         public ?string $scopeName,
         public bool $injection = false,
@@ -48,5 +49,10 @@ class IncludePattern implements PatternInterface
         }
 
         return $resolved->compile($grammar, $grammars, $allowA, $allowG);
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
     }
 }

--- a/src/Grammar/Injections/Injection.php
+++ b/src/Grammar/Injections/Injection.php
@@ -10,6 +10,7 @@ use Phiki\Grammar\ParsedGrammar;
 class Injection implements PatternInterface, InjectionMatcherInterface
 {
     public function __construct(
+        public int $id,
         public Selector $selector,
         public PatternInterface $pattern,
     ) {}
@@ -37,5 +38,10 @@ class Injection implements PatternInterface, InjectionMatcherInterface
     public function compile(ParsedGrammar $grammar, GrammarRepositoryInterface $grammars, bool $allowA, bool $allowG): array
     {
         return $this->pattern->compile($grammar, $grammars, $allowA, $allowG);
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
     }
 }

--- a/src/Grammar/MatchPattern.php
+++ b/src/Grammar/MatchPattern.php
@@ -13,6 +13,7 @@ class MatchPattern implements PatternInterface
      * @param  Capture[]  $captures
      */
     public function __construct(
+        public int $id,
         public Regex $match,
         public ?string $name,
         public array $captures = [],
@@ -38,5 +39,10 @@ class MatchPattern implements PatternInterface
         return [
             [$this, $this->match->get($allowA, $allowG)],
         ];
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
     }
 }

--- a/src/Grammar/ParsedGrammar.php
+++ b/src/Grammar/ParsedGrammar.php
@@ -63,4 +63,9 @@ final class ParsedGrammar implements PatternInterface
 
         return $parser->parse($grammar);
     }
+
+    public function getId(): int
+    {
+        return 0;
+    }
 }

--- a/src/Grammar/WhilePattern.php
+++ b/src/Grammar/WhilePattern.php
@@ -10,6 +10,7 @@ use Phiki\Support\Str;
 class WhilePattern implements PatternInterface
 {
     public function __construct(
+        public int $id,
         public MatchedPattern $begin,
         public Regex $while,
         public ?string $name,
@@ -48,5 +49,10 @@ class WhilePattern implements PatternInterface
         }
 
         return $compiled;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
     }
 }

--- a/src/TextMate/PatternSearcher.php
+++ b/src/TextMate/PatternSearcher.php
@@ -39,7 +39,7 @@ class PatternSearcher
         $bestPattern = null;
 
         foreach ($patterns as [$pattern, $regex]) {
-            if (! @mb_ereg_search_init($lineText, $regex)) {
+            if (! mb_ereg_search_init($lineText, $regex)) {
                 continue;
             }
 

--- a/src/TextMate/StateStack.php
+++ b/src/TextMate/StateStack.php
@@ -97,7 +97,7 @@ class StateStack
         $el = $this;
 
         while ($el !== null && $el->enterPos === $other->enterPos) {
-            if ($el->pattern === $other->pattern) {
+            if ($el->pattern->getId() === $other->pattern->getId()) {
                 return true;
             }
 

--- a/src/TextMate/Tokenizer.php
+++ b/src/TextMate/Tokenizer.php
@@ -82,12 +82,6 @@ class Tokenizer
         $stop = false;
 
         while (! $stop) {
-            if ($linePos >= $lineLength) {
-                // If we've reached the end of the line, we can produce any remaining tokens and stop processing.
-                $lineTokens->produce($stack, $lineLength);
-                break;
-            }
-
             // Find the next matching rule or injection.
             $rule = $this->matchRuleOrInjections($grammar, $lineText, $isFirstLine, $linePos, $stack, $anchorPosition);
 
@@ -256,7 +250,7 @@ class Tokenizer
             if ($captureRule->retokenizeCapturedWithRule()) {
                 $scopeName = $captureRule->getScopeName($matches);
                 $nameScopesList = $stack->contentNameScopesList->push($scopeName);
-                $stackClone = $stack->push(new CollectionPattern($captureRule->patterns), $match[1], -1, false, null, $nameScopesList, $nameScopesList);
+                $stackClone = $stack->push($captureRule->pattern, $match[1], -1, false, null, $nameScopesList, $nameScopesList);
                 $this->tokenizeString($grammar, mb_substr($lineText, 0, strlen($match[0]) + $match[1]), $isFirstLine && $match[1] === 0, $match[1], $stackClone, $lineTokens, false);
                 continue;
             }

--- a/src/TextMate/Tokenizer.php
+++ b/src/TextMate/Tokenizer.php
@@ -82,6 +82,12 @@ class Tokenizer
         $stop = false;
 
         while (! $stop) {
+            if ($linePos >= $lineLength) {
+                // If we've reached the end of the line, we can produce any remaining tokens and stop processing.
+                $lineTokens->produce($stack, $lineLength);
+                break;
+            }
+
             // Find the next matching rule or injection.
             $rule = $this->matchRuleOrInjections($grammar, $lineText, $isFirstLine, $linePos, $stack, $anchorPosition);
 

--- a/tests/Fixtures/samples/svelte.sample
+++ b/tests/Fixtures/samples/svelte.sample
@@ -1,28 +1,2 @@
 <script>
-	let files;
-
-	$: if (files) {
-		// Note that `files` is of type `FileList`, not an Array:
-		// https://developer.mozilla.org/en-US/docs/Web/API/FileList
-		console.log(files);
-
-		for (const file of files) {
-			console.log(`${file.name}: ${file.size} bytes`);
-		}
-	}
 </script>
-
-<label for="avatar">Upload a picture:</label>
-<input accept="image/png, image/jpeg" bind:files id="avatar" name="avatar" type="file" />
-
-<label for="many">Upload multiple files of any type:</label>
-<input bind:files id="many" multiple type="file" />
-
-{#if files}
-	<h2>Selected files:</h2>
-	{#each Array.from(files) as file}
-		<p>{file.name} ({file.size} bytes)</p>
-	{/each}
-{/if}
-
-// From https://svelte.dev/examples/file-inputs


### PR DESCRIPTION
Closes #79.

Our implementation is different to `vscode-textmate` since we use `EndPattern` instead of storing the `endRule` alongside the `BeginEndPattern`.

This means we can't check to see if two stack frames are identical to prevent infinite loops because the `EndPattern` will never be identical to a `BeginEndPattern`.

I've changed this so that patterns now store an `id` that is generated during parsing which we can use to compare them instead.