### PR TITLE
[2.x] Silence warnings from `mb_ereg_search_reg`

### DIFF
--- a/src/TextMate/PatternSearcher.php
+++ b/src/TextMate/PatternSearcher.php
@@ -9,6 +9,8 @@ use Phiki\Exceptions\GenericPatternException;
 use Phiki\Grammar\MatchedPattern;
 use Phiki\Grammar\ParsedGrammar;
 use Phiki\Grammar\WhilePattern;
+use Phiki\Support\Warnings;
+use Throwable;
 use ValueError;
 
 class PatternSearcher
@@ -39,7 +41,7 @@ class PatternSearcher
         $bestPattern = null;
 
         foreach ($patterns as [$pattern, $regex]) {
-            if (! mb_ereg_search_init($lineText, $regex)) {
+            if (! @mb_ereg_search_init($lineText, $regex)) {
                 continue;
             }
 


### PR DESCRIPTION
These were silenced before, but I unsilenced them when debugging some Svelte things.

Some grammars are just a bit rubbish and include invalid RegEx syntax so it's better to silence them from Phiki instead of flooding end-user logs with the rubbish.