### PR TITLE
[2.x] Fix `GrammarParser` respecting non-numeric capture keys

### DIFF
--- a/meta/update-grammars-and-themes.js
+++ b/meta/update-grammars-and-themes.js
@@ -9,7 +9,7 @@ console.log("Updating grammars...");
 const cases = {}
 const aliases = {}
 const scopeNames = {}
-const exclusions = ["source.bicep", "text.xml"];
+const exclusions = ["source.bicep"];
 
 grammars.forEach(grammar => {
     if (grammar.injectTo) {

--- a/src/Grammar/Grammar.php
+++ b/src/Grammar/Grammar.php
@@ -223,6 +223,7 @@ enum Grammar: string
     case Wikitext = 'wikitext';
     case Wit = 'wit';
     case Wolfram = 'wolfram';
+    case Xml = 'xml';
     case Xsl = 'xsl';
     case Yaml = 'yaml';
     case Zenscript = 'zenscript';
@@ -446,6 +447,7 @@ enum Grammar: string
             self::Wikitext => ["mediawiki","wiki"],
             self::Wit => [],
             self::Wolfram => ["wl"],
+            self::Xml => [],
             self::Xsl => [],
             self::Yaml => ["yml"],
             self::Zenscript => [],
@@ -673,6 +675,7 @@ enum Grammar: string
             self::Wikitext => 'source.wikitext',
             self::Wit => 'source.wit',
             self::Wolfram => 'source.wolfram',
+            self::Xml => 'text.xml',
             self::Xsl => 'text.xml.xsl',
             self::Yaml => 'source.yaml',
             self::Zenscript => 'source.zenscript',

--- a/src/Grammar/GrammarParser.php
+++ b/src/Grammar/GrammarParser.php
@@ -156,8 +156,8 @@ class GrammarParser
             $result[$index] = $this->capture($capture, strval($index));
         }
 
-        $captureIndices = array_keys($result);
-        $maxCaptureIdx = $captureIndices === [] ? 0 : max(array_keys($result));
+        $captureIndices = array_filter(array_keys($result), fn ($index) => is_numeric($index));
+        $maxCaptureIdx = $captureIndices === [] ? 0 : max($captureIndices);
 
         for ($i = 0; $i <= $maxCaptureIdx; $i++) {
             if (! isset($result[$i])) {


### PR DESCRIPTION
Closes #80.

We have some logic inside of `GrammarParser` to fill in missing capture indexes such that a grammar that only specifies capture rules for indexes `1` and `5` will be parsed and produce a `Capture` object with capture rules for indexes `0..5` where the missing ones are empty.

The problem is that grammars such as the XML grammar have invalid keys inside of `"captures"` because their grammar files are kind of messed up.

Ignoring any non-numeric keys fixes the problem.