### PR TITLE
[2.x] Implement `AddClassesTransformer`

### DIFF
--- a/src/Contracts/TransformerInterface.php
+++ b/src/Contracts/TransformerInterface.php
@@ -45,8 +45,10 @@ interface TransformerInterface
 
     /**
      * Modify the <span> for each line.
+     * 
+     * @param array<int, HighlightedToken> $line
      */
-    public function line(Element $line, int $index): Element;
+    public function line(Element $span, array $line, int $index): Element;
 
     /**
      * Modify the <span> for each token.

--- a/src/Contracts/TransformerInterface.php
+++ b/src/Contracts/TransformerInterface.php
@@ -46,12 +46,12 @@ interface TransformerInterface
     /**
      * Modify the <span> for each line.
      */
-    public function line(Element $line): Element;
+    public function line(Element $line, int $index): Element;
 
     /**
      * Modify the <span> for each token.
      */
-    public function token(Element $token): Element;
+    public function token(Element $token, int $index, int $line): Element;
 
     /**
      * Modify the HTML output after the AST has been converted.

--- a/src/Contracts/TransformerInterface.php
+++ b/src/Contracts/TransformerInterface.php
@@ -51,7 +51,7 @@ interface TransformerInterface
     /**
      * Modify the <span> for each token.
      */
-    public function token(Element $token, int $index, int $line): Element;
+    public function token(Element $span, HighlightedToken $token, int $index, int $line): Element;
 
     /**
      * Modify the HTML output after the AST has been converted.

--- a/src/Output/Html/PendingHtmlOutput.php
+++ b/src/Output/Html/PendingHtmlOutput.php
@@ -175,7 +175,7 @@ class PendingHtmlOutput implements Stringable
                 $line->children[] = $span;
             }
 
-            [$line, ] = $this->callTransformerMethod('line', $line, $index);
+            [$line, ] = $this->callTransformerMethod('line', $line, $lineTokens, $index);
 
             $code->children[] = $line;
         }

--- a/src/Output/Html/PendingHtmlOutput.php
+++ b/src/Output/Html/PendingHtmlOutput.php
@@ -73,19 +73,19 @@ class PendingHtmlOutput implements Stringable
         return $this->__toString();
     }
 
-    protected function callTransformerMethod(string $method, mixed $arg): mixed
+    protected function callTransformerMethod(string $method, mixed ...$args): mixed
     {
         if ($this->transformers === []) {
-            return $arg;
+            return $args;
         }
 
         foreach ($this->transformers as $transformer) {
             if (method_exists($transformer, $method)) {
-                $arg = $transformer->{$method}($arg);
+                $args[0] = $transformer->{$method}(...$args);
             }
         }
 
-        return $arg;
+        return $args;
     }
 
     private function getDefaultTheme(): ParsedTheme
@@ -100,9 +100,9 @@ class PendingHtmlOutput implements Stringable
 
     public function __toString(): string
     {
-        $code = $this->callTransformerMethod('preprocess', $this->code);
-        $tokens = $this->callTransformerMethod('tokens', call_user_func($this->generateTokensUsing, $code, $this->grammar));
-        $highlightedTokens = $this->callTransformerMethod('highlighted', call_user_func($this->highlightTokensUsing, $tokens, $this->themes));
+        [$code] = $this->callTransformerMethod('preprocess', $this->code);
+        [$tokens] = $this->callTransformerMethod('tokens', call_user_func($this->generateTokensUsing, $code, $this->grammar));
+        [$highlightedTokens] = $this->callTransformerMethod('highlighted', call_user_func($this->highlightTokensUsing, $tokens, $this->themes));
 
         $pre = new Element('pre');
 
@@ -155,7 +155,7 @@ class PendingHtmlOutput implements Stringable
                 $gutter->children[] = new Text(sprintf('%2d', $index + 1));
             }
 
-            foreach ($lineTokens as $token) {
+            foreach ($lineTokens as $j => $token) {
                 $span = new Element('span');
 
                 $tokenStyles = [($token->settings[$this->getDefaultThemeId()] ?? null)?->toStyleString()];
@@ -170,18 +170,24 @@ class PendingHtmlOutput implements Stringable
                 $span->properties->set('style', implode(';', array_filter($tokenStyles)));
                 $span->children[] = new Text(htmlspecialchars($token->token->text));
 
-                $line->children[] = $this->callTransformerMethod('token', $span);
+                [$span, ] = $this->callTransformerMethod('token', $span, $token, $j, $index);
+
+                $line->children[] = $span;
             }
 
-            $code->children[] = $this->callTransformerMethod('line', $line);
+            [$line, ] = $this->callTransformerMethod('line', $line, $index);
+
+            $code->children[] = $line;
         }
 
-        $pre->children[] = $this->callTransformerMethod('code', $code);
-        $pre = $this->callTransformerMethod('pre', $pre);
-        $root = $this->callTransformerMethod('root', new Root([$pre]));
+        [$code] = $this->callTransformerMethod('code', $code);
 
-        $html = $root->__toString();
+        $pre->children[] = $code;
 
-        return $this->callTransformerMethod('postprocess', $html);
+        [$pre] = $this->callTransformerMethod('pre', $pre);
+        [$root] = $this->callTransformerMethod('root', new Root([$pre]));
+        [$html] = $this->callTransformerMethod('postprocess', $root->__toString());
+
+        return $html;
     }
 }

--- a/src/Transformers/AbstractTransformer.php
+++ b/src/Transformers/AbstractTransformer.php
@@ -65,7 +65,7 @@ class AbstractTransformer implements TransformerInterface
     /**
      * Modify the <span> for each line.
      */
-    public function line(Element $line): Element
+    public function line(Element $line, int $index): Element
     {
         return $line;
     }
@@ -73,7 +73,7 @@ class AbstractTransformer implements TransformerInterface
     /**
      * Modify the <span> for each token.
      */
-    public function token(Element $token): Element
+    public function token(Element $token, int $index, int $line): Element
     {
         return $token;
     }

--- a/src/Transformers/AbstractTransformer.php
+++ b/src/Transformers/AbstractTransformer.php
@@ -64,10 +64,12 @@ class AbstractTransformer implements TransformerInterface
 
     /**
      * Modify the <span> for each line.
+     * 
+     * @param array<int, HighlightedToken> $tokens
      */
-    public function line(Element $line, int $index): Element
+    public function line(Element $span, array $tokens, int $index): Element
     {
-        return $line;
+        return $span;
     }
 
     /**

--- a/src/Transformers/AbstractTransformer.php
+++ b/src/Transformers/AbstractTransformer.php
@@ -73,9 +73,9 @@ class AbstractTransformer implements TransformerInterface
     /**
      * Modify the <span> for each token.
      */
-    public function token(Element $token, int $index, int $line): Element
+    public function token(Element $span, HighlightedToken $token, int $index, int $line): Element
     {
-        return $token;
+        return $span;
     }
 
     /**

--- a/src/Transformers/AddClassesTransformer.php
+++ b/src/Transformers/AddClassesTransformer.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Phiki\Transformers;
+
+class AddClassesTransformer extends AbstractTransformer
+{
+    //
+}

--- a/src/Transformers/AddClassesTransformer.php
+++ b/src/Transformers/AddClassesTransformer.php
@@ -2,7 +2,34 @@
 
 namespace Phiki\Transformers;
 
+use Phiki\Phast\ClassList;
+use Phiki\Phast\Element;
+use Phiki\Token\HighlightedToken;
+
 class AddClassesTransformer extends AbstractTransformer
 {
-    //
+    /**
+     * Create a new instance.
+     */
+    public function __construct(private bool $retainStyles = true) {}
+
+    /**
+     * Modify the `<span>` for each token.
+     */
+    public function token(Element $span, HighlightedToken $token, int $index, int $line): Element
+    {
+        $classList = $span->properties->get('class') ?? new ClassList();
+        
+        foreach ($token->token->scopes as $scope) {
+            $classList->add('phiki-' . $scope);
+        }
+
+        $span->properties->set('class', $classList);
+
+        if (! $this->retainStyles) {
+            $span->properties->remove('style');
+        }
+
+        return $span;
+    }
 }

--- a/tests/Fixtures/UselessTransformer.php
+++ b/tests/Fixtures/UselessTransformer.php
@@ -68,14 +68,14 @@ class UselessTransformer implements TransformerInterface
         return $code;
     }
 
-    public function line(Element $line): Element
+    public function line(Element $line, int $index): Element
     {
         $this->line = true;
 
         return $line;
     }
 
-    public function token(Element $token): Element
+    public function token(Element $token, int $index, int $line): Element
     {
         $this->token = true;
 

--- a/tests/Fixtures/UselessTransformer.php
+++ b/tests/Fixtures/UselessTransformer.php
@@ -69,11 +69,11 @@ class UselessTransformer implements TransformerInterface
         return $code;
     }
 
-    public function line(Element $line, int $index): Element
+    public function line(Element $span, array $line, int $index): Element
     {
         $this->line = true;
 
-        return $line;
+        return $span;
     }
 
     public function token(Element $span, HighlightedToken $token, int $index, int $line): Element

--- a/tests/Fixtures/UselessTransformer.php
+++ b/tests/Fixtures/UselessTransformer.php
@@ -5,6 +5,7 @@ namespace Phiki\Tests\Fixtures;
 use Phiki\Contracts\TransformerInterface;
 use Phiki\Phast\Root;
 use Phiki\Phast\Element;
+use Phiki\Token\HighlightedToken;
 
 class UselessTransformer implements TransformerInterface
 {
@@ -75,11 +76,11 @@ class UselessTransformer implements TransformerInterface
         return $line;
     }
 
-    public function token(Element $token, int $index, int $line): Element
+    public function token(Element $span, HighlightedToken $token, int $index, int $line): Element
     {
         $this->token = true;
 
-        return $token;
+        return $span;
     }
 
     public function postprocess(string $html): string

--- a/tests/Unit/Transformers/AddClassesTransformerTest.php
+++ b/tests/Unit/Transformers/AddClassesTransformerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Phiki\Grammar\Grammar;
+use Phiki\Phiki;
+use Phiki\Theme\Theme;
+use Phiki\Transformers\AddClassesTransformer;
+
+it('adds classes to each token element', function () {
+    $output = (new Phiki)
+        ->codeToHtml(
+            <<<'PHP'
+            echo "Hello, world!";
+            PHP,
+            Grammar::Php,
+            Theme::GithubLight,
+        )
+        ->transformer(new AddClassesTransformer())
+        ->toString();
+
+    expect($output)->toContain("phiki-source.php");
+});
+
+it('can remove the style attribute', function () {
+    $output = (new Phiki)
+        ->codeToHtml(
+            <<<'PHP'
+            echo "Hello, world!";
+            PHP,
+            Grammar::Php,
+            Theme::GithubLight,
+        )
+        ->transformer(new AddClassesTransformer(retainStyles: false))
+        ->toString();
+
+    expect($output)->toContain('<span class="token phiki-source.php">');
+});


### PR DESCRIPTION
This new first-party transformer adds support for additional `class` attributes on token spans, so you can override styles from CSS more easily.

By default it adds the classes alongside the `style` attributes but you can use `styles: false` on the constructor to remove the `style` attributes from tokens.

There are also some API changes to the `TransformerInterface` to make this sort of thing easier.