### PR TITLE
Add ability to specify the starting line number

### DIFF
--- a/src/Generators/HtmlGenerator.php
+++ b/src/Generators/HtmlGenerator.php
@@ -16,6 +16,7 @@ class HtmlGenerator implements OutputGeneratorInterface
         protected array $themes,
         protected bool $withGutter = false,
         protected bool $withWrapper = false,
+        protected int $startingLineNumber = 1,
     ) {}
 
     public function generate(array $tokens): string
@@ -89,7 +90,7 @@ class HtmlGenerator implements OutputGeneratorInterface
         $output = [];
 
         if ($this->withGutter) {
-            $output[] = $this->buildLineNumber($index + 1);
+            $output[] = $this->buildLineNumber($index + $this->startingLineNumber);
         }
 
         foreach ($line as $token) {

--- a/src/Phiki.php
+++ b/src/Phiki.php
@@ -67,7 +67,7 @@ class Phiki
      * @param  bool  $withGutter  Include a gutter in the generated HTML. The gutter typically contains line numbers and helps provide context for the code.
      * @param  bool  $withWrapper  Wrap the generated HTML in an additional `<div>` so that it can be styled with CSS. Useful for avoiding overflow issues.
      */
-    public function codeToHtml(string $code, string|Grammar $grammar, string|array|Theme $theme, bool $withGutter = false, bool $withWrapper = false): string
+    public function codeToHtml(string $code, string|Grammar $grammar, string|array|Theme $theme, bool $withGutter = false, bool $withWrapper = false, int $startingLineNumber = 1): string
     {
         $tokens = $this->codeToHighlightedTokens($code, $grammar, $theme);
         $generator = new HtmlGenerator(
@@ -78,6 +78,7 @@ class Phiki
             $this->wrapThemes($theme),
             $withGutter,
             $withWrapper,
+            $startingLineNumber,
         );
 
         return $generator->generate($tokens);

--- a/tests/Unit/PhikiTest.php
+++ b/tests/Unit/PhikiTest.php
@@ -57,6 +57,22 @@ describe('Phiki', function () {
         expect((new Phiki)->codeToHtml('echo $a;', Grammar::Php, Theme::GithubDark))->toBeString();
     });
 
+    it('can generate line numbers', function () {
+        $html = (new Phiki)->codeToHtml(<<<'PHP'
+        echo "Hello, world";
+        PHP, Grammar::Php, 'github-dark', withGutter: true);
+
+        expect($html)->toContain('<span class="line-number" style="color: #444d56; -webkit-user-select: none; user-select: none;"> 1</span>');
+    });
+
+    it('can generate line numbers with a starting line number', function () {
+        $html = (new Phiki)->codeToHtml(<<<'PHP'
+        echo "Hello, world";
+        PHP, Grammar::Php, 'github-dark', withGutter: true, startingLineNumber: 10);
+
+        expect($html)->toContain('<span class="line-number" style="color: #444d56; -webkit-user-select: none; user-select: none;">10</span>');
+    });
+
     it('can detect the grammar of code', function () {
         expect((new Phiki)->detectGrammar('<?php echo "Hello, world";'))->toBe(Grammar::Php);
         expect((new Phiki)->detectGrammar('console.log("Hello, world");'))->toBe(Grammar::Javascript);


### PR DESCRIPTION
`Phiki::codeToHtml` generates line numbers starting from 1. This PR adds the ability to specify the starting line number.