### PR TITLE
[2.x] Only initialize the tokenizer once

### DIFF
--- a/src/Exceptions/FailedToInitializePatternSearchException.php
+++ b/src/Exceptions/FailedToInitializePatternSearchException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Phiki\Exceptions;
+
+use Exception;
+
+class FailedToInitializePatternSearchException extends Exception
+{
+    //
+}

--- a/src/TextMate/PatternSearcher.php
+++ b/src/TextMate/PatternSearcher.php
@@ -4,6 +4,7 @@ namespace Phiki\TextMate;
 
 use Phiki\Contracts\GrammarRepositoryInterface;
 use Phiki\Contracts\PatternInterface;
+use Phiki\Exceptions\FailedToInitializePatternSearchException;
 use Phiki\Exceptions\FailedToSetSearchPositionException;
 use Phiki\Grammar\MatchedPattern;
 use Phiki\Grammar\ParsedGrammar;
@@ -36,16 +37,16 @@ class PatternSearcher
         $bestMatches = null;
         $bestPattern = null;
 
-        foreach ($patterns as [$pattern, $regex]) {
-            if (! @mb_ereg_search_init($lineText, $regex)) {
-                continue;
-            }
+        if (! mb_ereg_search_init($lineText)) {
+            throw new FailedToInitializePatternSearchException;
+        }
 
+        foreach ($patterns as [$pattern, $regex]) {
             if (! mb_ereg_search_setpos($linePos)) {
                 throw new FailedToSetSearchPositionException;
             }
 
-            $result = mb_ereg_search_pos();
+            $result = mb_ereg_search_pos($regex);
 
             if ($result === false) {
                 continue;


### PR DESCRIPTION
We were previously setting the RegEx search text for each pattern being tried. This isn't necessary and we can instead just specify the pattern we're searching for through `mb_ereg_search_pos()`.