### PR TITLE
[2.x] Fix pattern searcher not breaking early if match found at linePos

### DIFF
--- a/src/TextMate/PatternSearcher.php
+++ b/src/TextMate/PatternSearcher.php
@@ -54,7 +54,7 @@ class PatternSearcher
 
             [$start, $length] = $result;
 
-            if ($start === 0) {
+            if ($start === $linePos) {
                 $bestLocation = $start;
                 $bestMatches = mb_ereg_search_getregs();
                 $bestLength = $length;


### PR DESCRIPTION
`PatternSearcher` would only break early if the match started at `$linePos === 0`, but this isn't an effective early return as `$linePos` is more than likely going to be beyond `0`.

This should offer a small performance boost as it won't need to iterate over every single pattern every single time.