### PR TITLE
[2.x] Caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require": {
         "php": "^8.2",
         "league/commonmark": "^2.5.3",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "psr/simple-cache": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/docs/caching.mdx
+++ b/docs/caching.mdx
@@ -1,0 +1,40 @@
+---
+title: Caching
+---
+
+Syntax highlighting can be a resource-intensive operation, especially for large code snippets or when processing many snippets in a short period.
+
+To improve performance, Phiki includes a built-in caching mechanism built around the `psr/simple-cache` interface.
+
+## Enabling caching
+
+Enabling caching is as simple as providing a cache implementation to the `Phiki::cache()` method.
+
+```php
+class SimpleCache implements \Psr\SimpleCache\CacheInterface
+{
+    // ...
+}
+
+$phiki = (new Phiki)
+    ->cache(new SimpleCache);
+```
+
+This will enable caching for all subsequent calls to `codeToHtml()`. The cache will store the generated HTML for each unique combination of code, grammar, theme(s), gutter setting and `Transformer` class.
+
+## Cache invalidation
+
+Phiki does not include any built-in cache invalidation mechanism apart from a change in the cache key.
+
+If you need to invalidate the cache for any reason, you must do so using the methods provided by your chosen cache implementation.
+
+## Caching individual snippets
+
+If you don't want to cache all syntax highlighted code, you can also cache individual `codeToHtml()` calls by passing a cache implementation to the `PendingHtmlOutput::cache()` method.
+
+```php
+$html = (new Phiki)
+    ->codeToHtml("<?php echo ...", Grammar::Php, Theme::GithubLight)
+    ->cache(new SimpleCache)
+    ->toString();
+```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -22,7 +22,8 @@
                 "pages": [
                     "installation",
                     "highlighting-code",
-                    "multi-themes"
+                    "multi-themes",
+                    "caching"
                 ]
             },
             {

--- a/docs/laravel.mdx
+++ b/docs/laravel.mdx
@@ -50,6 +50,37 @@ class AppServiceProvider extends ServiceProvider
 }
 ```
 
+### Caching
+
+Phiki automatically enables caching when used in a Laravel application. It uses your application's default cache store (`CACHE_STORE`) to cache highlighted code blocks.
+
+If you wish to customize the cache store used by Phiki, you can do so in the `boot` method of a service provider.
+
+```php
+use Phiki\Adapters\Laravel\Facades\Phiki;
+use Illuminate\Support\Facades\Cache;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Phiki::cache(Cache::store('redis'));
+    }
+}
+```
+
+#### Cache invalidation
+
+Phiki's cache key is based on the content of the code block, the grammar, the themes chosen, the gutter setting, and any transformers used.
+
+If any of these change, Phiki will automatically generate a new cache key and re-highlight the code block.
+
+If you need to manually clear Phiki's cache, you can do so by calling the `php artisan cache:clear` command, which will clear the entire cache for your application.
+
+```sh
+php artisan cache:clear
+```
+
 ## `Str::markdown()`
 
 If you're using the `Str::markdown()` helper method, you can use Phiki's [CommonMark](/commonmark) extension to highlight code blocks inside of your Markdown.
@@ -57,10 +88,11 @@ If you're using the `Str::markdown()` helper method, you can use Phiki's [Common
 ```php
 use Illuminate\Support\Str;
 use Phiki\Adapters\CommonMark\PhikiExtension;
+use Phiki\Phiki;
 use Phiki\Theme\Theme;
 
 Str::markdown($markdown, extensions: [
-    new PhikiExtension(Theme::GithubLight),
+    new PhikiExtension(Theme::GithubLight, resolve(Phiki::class)),
 ]);
 ```
 
@@ -72,9 +104,10 @@ As per the documentation on Phiki's [gutter](/highlighting-code), you can enable
 use Illuminate\Support\Str;
 use Phiki\Adapters\CommonMark\PhikiExtension;
 use Phiki\Theme\Theme;
+use Phiki\Phiki;
 
 Str::markdown($markdown, extensions: [
-    new PhikiExtension(Theme::GithubLight, withGutter: true),
+    new PhikiExtension(Theme::GithubLight, resolve(Phiki::class), withGutter: true),
 ]);
 ```
 
@@ -85,13 +118,14 @@ As per the documentation on [Multiple themes](/multiple-themes), you can also pa
 ```php
 use Illuminate\Support\Str;
 use Phiki\Adapters\CommonMark\PhikiExtension;
+use Phiki\Phiki;
 use Phiki\Theme\Theme;
 
 Str::markdown($markdown, extensions: [
     new PhikiExtension([
         'light' => Theme::GithubLight,
         'dark' => Theme::GithubDark,
-    ]),
+    ], resolve(Phiki::class)),
 ]);
 ```
 

--- a/src/Adapters/Laravel/Facades/Phiki.php
+++ b/src/Adapters/Laravel/Facades/Phiki.php
@@ -9,9 +9,11 @@ use Illuminate\Support\Facades\Facade;
  * @method static array<int, array<int, \Phiki\Token\HighlightedToken>> tokensToHighlightedTokens(array<int, array<int, \Phiki\Token\Token>> $tokens, string|array|\Phiki\Theme\Theme $theme)
  * @method static array<int, array<int, \Phiki\Token\HighlightedToken>> codeToHighlightedTokens(string $code, string|\Phiki\Grammar\Grammar $grammar, string|array|\Phiki\Theme\Theme $theme)
  * @method static \Phiki\Output\Html\PendingHtmlOutput codeToHtml(string $code, string|\Phiki\Grammar\Grammar $grammar, string|array|\Phiki\Theme\Theme $theme)
+ * @method static \Phiki\Environment environment()
  * @method static \Phiki\Phiki extend(\Phiki\Contracts\ExtensionInterface $extension)
  * @method static \Phiki\Phiki grammar(string $name, string|\Phiki\Grammar\ParsedGrammar $pathOrGrammar)
  * @method static \Phiki\Phiki theme(string $name, string|\Phiki\Theme\ParsedTheme $pathOrTheme)
+ * @method static \Phiki\Phiki cache(\Psr\SimpleCache\CacheInterface $cache)
  * 
  * @see \Phiki\Phiki
  */

--- a/src/Adapters/Laravel/PhikiServiceProvider.php
+++ b/src/Adapters/Laravel/PhikiServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Phiki\Adapters\Laravel;
 
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\ServiceProvider;
 use Phiki\Phiki;
 
@@ -13,7 +14,7 @@ class PhikiServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app->singleton(Phiki::class, static fn () => new Phiki);    
+        $this->app->singleton(Phiki::class, static fn () => (new Phiki)->cache(Cache::store()));
     }
 
     /**

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -9,12 +9,15 @@ use Phiki\Grammar\ParsedGrammar;
 use Phiki\Theme\ParsedTheme;
 use Phiki\Theme\Theme;
 use Phiki\Theme\ThemeRepository;
+use Psr\SimpleCache\CacheInterface;
 
 class Environment
 {
     public readonly GrammarRepository $grammars;
 
     public readonly ThemeRepository $themes;
+
+    public ?CacheInterface $cache = null;
 
     public function __construct()
     {
@@ -39,6 +42,13 @@ class Environment
     public function theme(string $slug, string|ParsedTheme $theme): static
     {
         $this->themes->register($slug, $theme);
+
+        return $this;
+    }
+
+    public function cache(CacheInterface $cache): static
+    {
+        $this->cache = $cache;
 
         return $this;
     }

--- a/src/Output/Html/PendingHtmlOutput.php
+++ b/src/Output/Html/PendingHtmlOutput.php
@@ -59,7 +59,7 @@ class PendingHtmlOutput implements Stringable
         return $this;
     }
 
-    public function cache(CacheInterface $cache): self
+    public function cache(?CacheInterface $cache): self
     {
         $this->cache = $cache;
 
@@ -132,7 +132,9 @@ class PendingHtmlOutput implements Stringable
 
     public function __toString(): string
     {
-        if (isset($this->cache) && $this->cache->has($cacheKey = $this->cacheKey())) {
+        $cacheKey = $this->cacheKey();
+
+        if (isset($this->cache) && $this->cache->has($cacheKey)) {
             return $this->cache->get($cacheKey);
         }
 

--- a/src/Output/Html/PendingHtmlOutput.php
+++ b/src/Output/Html/PendingHtmlOutput.php
@@ -13,6 +13,7 @@ use Phiki\Support\Arr;
 use Phiki\Theme\ParsedTheme;
 use Phiki\Token\HighlightedToken;
 use Phiki\Token\Token;
+use Psr\SimpleCache\CacheInterface;
 use Stringable;
 
 class PendingHtmlOutput implements Stringable
@@ -22,6 +23,8 @@ class PendingHtmlOutput implements Stringable
     protected ?Closure $generateTokensUsing = null;
 
     protected ?Closure $highlightTokensUsing = null;
+
+    protected ?CacheInterface $cache = null;
 
     protected array $transformers = [];
 
@@ -52,6 +55,13 @@ class PendingHtmlOutput implements Stringable
     public function highlightTokensUsing(Closure $callback): self
     {
         $this->highlightTokensUsing = $callback;
+
+        return $this;
+    }
+
+    public function cache(CacheInterface $cache): self
+    {
+        $this->cache = $cache;
 
         return $this;
     }

--- a/src/Output/Html/PendingHtmlOutput.php
+++ b/src/Output/Html/PendingHtmlOutput.php
@@ -92,6 +92,19 @@ class PendingHtmlOutput implements Stringable
         return $this->__toString();
     }
 
+    public function cacheKey(): string
+    {
+        return 'phiki_html_' . md5(serialize([
+            $this->code,
+            $this->grammar->scopeName,
+            array_keys($this->themes),
+            ...array_map(fn (ParsedTheme $theme) => $theme->name, $this->themes),
+            $this->withGutter,
+            $this->startingLineNumber,
+            ...array_map(fn (TransformerInterface $transformer) => get_class($transformer), $this->transformers),
+        ]));
+    }
+
     protected function callTransformerMethod(string $method, mixed ...$args): mixed
     {
         if ($this->transformers === []) {
@@ -119,6 +132,10 @@ class PendingHtmlOutput implements Stringable
 
     public function __toString(): string
     {
+        if (isset($this->cache) && $this->cache->has($cacheKey = $this->cacheKey())) {
+            return $this->cache->get($cacheKey);
+        }
+
         [$code] = $this->callTransformerMethod('preprocess', $this->code);
         [$tokens] = $this->callTransformerMethod('tokens', call_user_func($this->generateTokensUsing, $code, $this->grammar));
         [$highlightedTokens] = $this->callTransformerMethod('highlighted', call_user_func($this->highlightTokensUsing, $tokens, $this->themes));
@@ -206,6 +223,10 @@ class PendingHtmlOutput implements Stringable
         [$pre] = $this->callTransformerMethod('pre', $pre);
         [$root] = $this->callTransformerMethod('root', new Root([$pre]));
         [$html] = $this->callTransformerMethod('postprocess', $root->__toString());
+
+        if (isset($this->cache)) {
+            $this->cache->set($cacheKey, $html);
+        }
 
         return $html;
     }

--- a/src/Phiki.php
+++ b/src/Phiki.php
@@ -12,6 +12,7 @@ use Phiki\Support\Arr;
 use Phiki\TextMate\Tokenizer;
 use Phiki\Theme\ParsedTheme;
 use Phiki\Theme\Theme;
+use Psr\SimpleCache\CacheInterface;
 
 class Phiki
 {
@@ -85,6 +86,13 @@ class Phiki
     public function theme(string $name, string|ParsedTheme $pathOrTheme): static
     {
         $this->environment->themes->register($name, $pathOrTheme);
+
+        return $this;
+    }
+
+    public function cache(CacheInterface $cache): static
+    {
+        $this->environment->cache($cache);
 
         return $this;
     }

--- a/src/Phiki.php
+++ b/src/Phiki.php
@@ -56,6 +56,7 @@ class Phiki
     public function codeToHtml(string $code, string|Grammar $grammar, string|array|Theme $theme): PendingHtmlOutput
     {
         return (new PendingHtmlOutput($code, $this->environment->grammars->resolve($grammar), $this->wrapThemes($theme)))
+            ->cache($this->environment->cache)
             ->generateTokensUsing(fn (string $code, ParsedGrammar $grammar) => $this->codeToTokens($code, $grammar))
             ->highlightTokensUsing(fn (array $tokens, array $themes) => $this->tokensToHighlightedTokens($tokens, $themes));
     }

--- a/tests/Fixtures/FakeCache.php
+++ b/tests/Fixtures/FakeCache.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Phiki\Tests\Fixtures;
+
+use Psr\SimpleCache\CacheInterface;
+
+class FakeCache implements CacheInterface
+{
+    private array $store = [];
+
+    public function get($key, $default = null): mixed
+    {
+        return $this->store[$key] ?? $default;
+    }
+
+    public function set($key, $value, $ttl = null): bool
+    {
+        $this->store[$key] = $value;
+        return true;
+    }
+
+    public function delete($key): bool
+    {
+        unset($this->store[$key]);
+        return true;
+    }
+
+    public function clear(): bool
+    {
+        $this->store = [];
+        return true;
+    }
+
+    public function getMultiple($keys, $default = null): array
+    {
+        $results = [];
+        foreach ($keys as $key) {
+            $results[$key] = $this->get($key, $default);
+        }
+        return $results;
+    }
+
+    public function setMultiple($values, $ttl = null): bool
+    {
+        foreach ($values as $key => $value) {
+            $this->set($key, $value, $ttl);
+        }
+        return true;
+    }
+
+    public function deleteMultiple($keys): bool
+    {
+        foreach ($keys as $key) {
+            $this->delete($key);
+        }
+        return true;
+    }
+
+    public function has($key): bool
+    {
+        return array_key_exists($key, $this->store);
+    }
+}

--- a/tests/Unit/PendingHtmlOutputTest.php
+++ b/tests/Unit/PendingHtmlOutputTest.php
@@ -2,6 +2,7 @@
 
 use Phiki\Grammar\Grammar;
 use Phiki\Phiki;
+use Phiki\Tests\Fixtures\FakeCache;
 use Phiki\Tests\Fixtures\UselessTransformer;
 use Phiki\Theme\Theme;
 
@@ -56,4 +57,50 @@ it('can output line numbers', function () {
         ->toString();
 
     expect($html)->toContain('> 1</span');
+});
+
+it('can cache the generated HTML', function () {
+    $cache = new FakeCache;
+
+    $pending = (new Phiki)
+        ->codeToHtml(
+            <<<'PHP'
+            echo "Hello, world!";
+            PHP,
+            Grammar::Php,
+            Theme::GithubLight,
+        )
+        ->cache($cache);
+    
+    $pending->toString();
+
+    expect($cache->has($pending->cacheKey()))->toBeTrue();
+});
+
+it('can read from cache', function () {
+    $cache = new FakeCache;
+
+    $pending = (new Phiki)
+        ->codeToHtml(
+            <<<'PHP'
+            echo "Hello, world!";
+            PHP,
+            Grammar::Php,
+            Theme::GithubLight,
+        )
+        ->cache($cache);
+    
+    $pending->toString();
+
+    $pending2 = (new Phiki)
+        ->codeToHtml(
+            <<<'PHP'
+            echo "Hello, world!";
+            PHP,
+            Grammar::Php,
+            Theme::GithubLight,
+        )
+        ->cache($cache);
+
+    expect($pending2->toString())->toBe($pending->toString());
 });

--- a/tests/Unit/PhikiTest.php
+++ b/tests/Unit/PhikiTest.php
@@ -4,56 +4,54 @@ use Phiki\Grammar\Grammar;
 use Phiki\Phiki;
 use Phiki\Theme\Theme;
 
-describe('Phiki', function () {
-    it('can be constructed', function () {
-        expect(new Phiki)->toBeInstanceOf(Phiki::class);
-    });
+it('can be constructed', function () {
+    expect(new Phiki)->toBeInstanceOf(Phiki::class);
+});
 
-    it('can generate html from code', function () {
-        expect((new Phiki)->codeToHtml(<<<'PHP'
-        function add(int|float $a, int|float $b): int|float {
-            return $a + $b;
-        }
-        PHP, 'php', 'github-dark'))->toString()->toBeString();
-    });
+it('can generate html from code', function () {
+    expect((new Phiki)->codeToHtml(<<<'PHP'
+    function add(int|float $a, int|float $b): int|float {
+        return $a + $b;
+    }
+    PHP, 'php', 'github-dark'))->toString()->toBeString();
+});
 
-    it('adds a language data property and class if grammar has a name', function () {
-        $html = (new Phiki)->codeToHtml(<<<'PHP'
-        function add(int|float $a, int|float $b): int|float {
-            return $a + $b;
-        }
-        PHP, 'php', 'github-dark')->toString();
+it('adds a language data property and class if grammar has a name', function () {
+    $html = (new Phiki)->codeToHtml(<<<'PHP'
+    function add(int|float $a, int|float $b): int|float {
+        return $a + $b;
+    }
+    PHP, 'php', 'github-dark')->toString();
 
-        expect($html)->toContain('data-language="php"');
-        expect($html)->toContain('language-php');
-    });
+    expect($html)->toContain('data-language="php"');
+    expect($html)->toContain('language-php');
+});
 
-    it('does not add a language data property and class if grammar has no name', function () {
-        $html = (new Phiki)->codeToHtml(<<<'PHP'
-        function add(int|float $a, int|float $b): int|float {
-            return $a + $b;
-        }
-        PHP, Grammar::Txt, 'github-dark')->toString();
+it('does not add a language data property and class if grammar has no name', function () {
+    $html = (new Phiki)->codeToHtml(<<<'PHP'
+    function add(int|float $a, int|float $b): int|float {
+        return $a + $b;
+    }
+    PHP, Grammar::Txt, 'github-dark')->toString();
 
-        expect($html)->not->toContain('data-language');
-        expect($html)->not->toContain('language-');
-    });
+    expect($html)->not->toContain('data-language');
+    expect($html)->not->toContain('language-');
+});
 
-    it('can generate code with multiple themes', function () {
-        $code = (new Phiki)->codeToHtml(<<<'PHP'
-        echo "Hello, world";
-        PHP, Grammar::Php, ['light' => Theme::GithubLight, 'dark' => Theme::GithubDark])->toString();
+it('can generate code with multiple themes', function () {
+    $code = (new Phiki)->codeToHtml(<<<'PHP'
+    echo "Hello, world";
+    PHP, Grammar::Php, ['light' => Theme::GithubLight, 'dark' => Theme::GithubDark])->toString();
 
-        expect($code)->toContain('github-light')->toContain('github-dark');
-        expect($code)->toContain('--phiki-dark-color');
-        expect($code)->toContain('--phiki-dark-background-color');
-    });
+    expect($code)->toContain('github-light')->toContain('github-dark');
+    expect($code)->toContain('--phiki-dark-color');
+    expect($code)->toContain('--phiki-dark-background-color');
+});
 
-    it('accepts a grammar enum member', function () {
-        expect((new Phiki)->codeToTokens('echo $a;', Grammar::Php))->toBeArray();
-    });
+it('accepts a grammar enum member', function () {
+    expect((new Phiki)->codeToTokens('echo $a;', Grammar::Php))->toBeArray();
+});
 
-    it('accepts a theme enum member', function () {
-        expect((new Phiki)->codeToHtml('echo $a;', Grammar::Php, Theme::GithubDark))->__toString()->toBeString();
-    });
+it('accepts a theme enum member', function () {
+    expect((new Phiki)->codeToHtml('echo $a;', Grammar::Php, Theme::GithubDark))->__toString()->toBeString();
 });


### PR DESCRIPTION
This PR adds support for caching generated HTML using `psr/simple-cache` compatible objects.

You can enable caching by passing a `CacheInterface` object to the `->cache()` method of the `Phiki` class which will enable caching for all generated HTML, or you can pass it to a one-off `PendingHtmlOutput` object.

The Laravel adapter also has caching enabled right out of the box and will default to your apps regular cache store (`Cache::store()`) which is already PSR-compatible.