### PR TITLE
[2.x] Add support for line decorations

### DIFF
--- a/src/Output/Html/PendingHtmlOutput.php
+++ b/src/Output/Html/PendingHtmlOutput.php
@@ -13,6 +13,9 @@ use Phiki\Support\Arr;
 use Phiki\Theme\ParsedTheme;
 use Phiki\Token\HighlightedToken;
 use Phiki\Token\Token;
+use Phiki\Transformers\Decorations\DecorationsTransformer;
+use Phiki\Transformers\Decorations\DecorationTransformer;
+use Phiki\Transformers\Decorations\LineDecoration;
 use Psr\SimpleCache\CacheInterface;
 use Stringable;
 
@@ -27,6 +30,8 @@ class PendingHtmlOutput implements Stringable
     protected ?CacheInterface $cache = null;
 
     protected array $transformers = [];
+
+    protected array $decorations = [];
 
     protected int $startingLineNumber = 1;
 
@@ -76,6 +81,17 @@ class PendingHtmlOutput implements Stringable
     public function transformer(TransformerInterface $transformer): self
     {
         $this->transformers[] = $transformer;
+
+        return $this;
+    }
+
+    public function decoration(LineDecoration ...$decorations): self
+    {
+        if (! Arr::any($this->transformers, fn (TransformerInterface $transformer) => $transformer instanceof DecorationTransformer)) {
+            $this->transformers[] = new DecorationTransformer($this->decorations);
+        }
+
+        $this->decorations = array_merge($this->decorations, $decorations);
 
         return $this;
     }

--- a/src/Phast/ClassList.php
+++ b/src/Phast/ClassList.php
@@ -40,6 +40,11 @@ class ClassList implements Stringable
         return $this;
     }
 
+    public function all(): array
+    {
+        return $this->classes;
+    }
+
     public function __toString(): string
     {
         return implode(' ', array_filter($this->classes, fn (string $class) => trim($class) !== ''));

--- a/src/Transformers/Decorations/DecorationTransformer.php
+++ b/src/Transformers/Decorations/DecorationTransformer.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Phiki\Transformers\Decorations;
+
+use Phiki\Phast\Element;
+use Phiki\Transformers\AbstractTransformer;
+
+class DecorationTransformer extends AbstractTransformer
+{
+    /**
+     * @param array<int, LineDecoration> $decorations
+     */
+    public function __construct(
+        public array &$decorations,
+    ) {}
+
+    public function line(Element $span, array $tokens, int $index): Element
+    {
+        foreach ($this->decorations as $decoration) {
+            if (! $decoration->appliesToLine($index)) {
+                continue;
+            }
+
+            $span->properties->get('class')->add(...$decoration->classes->all());
+        }
+
+        return $span;
+    }
+}

--- a/src/Transformers/Decorations/LineDecoration.php
+++ b/src/Transformers/Decorations/LineDecoration.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Phiki\Transformers\Decorations;
+
+use Phiki\Phast\ClassList;
+
+class LineDecoration
+{
+    /**
+     * @param int | array<int> $line
+     */
+    public function __construct(
+        public int | array $line,
+        public ClassList $classes,
+    ) {}
+
+    public function appliesToLine(int $line): bool
+    {
+        return $this->line === $line || (is_array($this->line) && $line >= $this->line[0] && $line <= $this->line[1]);
+    }
+}

--- a/tests/Unit/Transformers/Decorations/DecorationTransformerTest.php
+++ b/tests/Unit/Transformers/Decorations/DecorationTransformerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Phiki\Grammar\Grammar;
+use Phiki\Phast\ClassList;
+use Phiki\Phiki;
+use Phiki\Theme\Theme;
+use Phiki\Transformers\Decorations\LineDecoration;
+
+it('can apply decorations to a line', function () {
+    $output = (new Phiki)
+        ->codeToHtml(<<<'PHP'
+        echo "Hello, world!";
+        PHP, Grammar::Php, Theme::GithubLight)
+        ->decoration(new LineDecoration(0, new ClassList(['test-class'])))
+        ->toString();
+
+    expect($output)->toContain('<span class="line test-class">');
+});
+
+it('can apply decorations to multiple lines with multiple instances', function () {
+    $output = (new Phiki)
+        ->codeToHtml(<<<'PHP'
+        echo "Hello, world!";
+        echo "Goodbye, world!";
+        PHP, Grammar::Php, Theme::GithubLight)
+        ->decoration(
+            new LineDecoration(0, new ClassList(['first-line'])),
+            new LineDecoration(1, new ClassList(['second-line'])),
+            new LineDecoration(0, new ClassList(['also-first-line'])),
+        )
+        ->toString();
+
+    expect($output)
+        ->toContain('<span class="line first-line also-first-line">')
+        ->toContain('<span class="line second-line">');
+});
+
+it('can apply decorations to a range of lines', function () {
+    $output = (new Phiki)
+        ->codeToHtml(<<<'PHP'
+        echo "Hello, world!";
+        echo "Goodbye, world!";
+        echo "Farewell, world!";
+        PHP, Grammar::Php, Theme::GithubLight)
+        ->decoration(new LineDecoration([0, 2], new ClassList(['multi-line'])))
+        ->toString();
+
+    expect(substr_count($output, 'multi-line'))->toBe(3);
+});


### PR DESCRIPTION
You can now apply decorations to a specific line, which right now means adding classes to a line of your choosing.

```php
(new Phiki)
    ->codeToHtml(...)
    ->decoration(new LineDecoration(0, new ClassList(['my-class']))
```

The first line (0-indexed lines) will now have the `my-class` class added to it.

I would like to add support for Shiki's `character` decorations too in the future, but there's quite a bit of logic involved with that since they can split tokens into multiple smaller tokens, creating wrapper elements, etc.