### PR TITLE
[2.x] Fix wrong method name on LineDecoration

### DIFF
--- a/docs/decorations.mdx
+++ b/docs/decorations.mdx
@@ -14,7 +14,7 @@ use Phiki\Transformers\Decorations\LineDecoration;
 $output = (new Phiki)
     ->codeToHtml('<?php echo ...', Grammar::Php, Theme::GithubLight)
     ->decoration(
-        LineDecoration::forLine(0)->addClass('focus'),
+        LineDecoration::forLine(0)->class('focus'),
     );
 ```
 


### PR DESCRIPTION
`addClass` doesn't exist on the `LineDecoration` class.