### PR TITLE
Verify `blade.compiler` is available before registering the component namespace

### DIFF
--- a/src/Adapters/Laravel/PhikiServiceProvider.php
+++ b/src/Adapters/Laravel/PhikiServiceProvider.php
@@ -22,8 +22,8 @@ class PhikiServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        if ($this->app->bound('blade.compiler')) {
-            Blade::componentNamespace('Phiki\\Adapters\\Laravel\\Components', 'phiki');
-        }
+        Blade::resolved(function ($blade) {
+            $blade->componentNamespace('Phiki\\Adapters\\Laravel\\Components', 'phiki');
+        });
     }
 }

--- a/src/Adapters/Laravel/PhikiServiceProvider.php
+++ b/src/Adapters/Laravel/PhikiServiceProvider.php
@@ -22,6 +22,8 @@ class PhikiServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Blade::componentNamespace('Phiki\\Adapters\\Laravel\\Components', 'phiki');
+        if ($this->app->bound('blade.compiler')) {
+            Blade::componentNamespace('Phiki\\Adapters\\Laravel\\Components', 'phiki');
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/57078

Laravel 12.29.0 added a dependency on `phiki/phiki`, which has a discoverable service provider to auto-register a Blade's component namespace.

In apps that opt out of loading Laravel's `ViewServiceProvider`, the `blade.compiler` binding proxied by the `Blade` façade is not available, which causes an error.

Console-only applications can opt out of some providers to reduce size when deployed as PHAR archives.

**This PR**

- Adds a guard around the Blade's component namespace registration to ensure the `blade.compiler` is bound to the container.