### PR TITLE
Fix tokenization of codes containing UTF-8 characters

### DIFF
--- a/src/TextMate/Tokenizer.php
+++ b/src/TextMate/Tokenizer.php
@@ -45,7 +45,7 @@ class Tokenizer
             contentNameScopesList: $scopeList,
         );
 
-        $lines = array_values(preg_split("/\R/", $text));
+        $lines = array_values(preg_split("/\R/u", $text));
         $tokens = [];
 
         foreach ($lines as $index => $line) {


### PR DESCRIPTION
This PR fixes tokenization of codes containing UTF-8 characters. Currently, following example throws a `Phiki\Exceptions\FailedToInitializePatternSearchException`, because of the `م` character:

```php
<?php

use Phiki\Phiki;
use Phiki\Grammar\Grammar;
use Phiki\Theme\Theme;

$code = <<<'PHP'
<?php

$str = 'م';
PHP;

$html = (new Phiki)
    ->codeToHtml($code, Grammar::Php, Theme::GithubLight)
    ->toString();
```

That's because of the breaking UTF-8 characters when splitting the code by newline character using `preg_split` without the PCRE_UTF8 flag:

```
array:4 [
  0 => "<?php"
  1 => ""
  2 => b"$str = 'Ù"
  3 => "';"
]
```

This PR solves that by enabling PCRE_UTF8 flag in `preg_split`. The output will be as expected:

```html
<pre class="phiki language-php github-light" data-language="php" style="background-color: #fff;color: #24292e;"><code><span class="line"><span class="token" style="color: #d73a49;">&lt;</span><span class="token" style="color: #d73a49;">?</span><span class="token" style="color: #005cc5;">php</span><span class="token">\n
</span></span><span class="line"><span class="token">\n
</span></span><span class="line"><span class="token" style="color: #24292e;">$</span><span class="token" style="color: #24292e;">str</span><span class="token"> </span><span class="token" style="color: #d73a49;">=</span><span class="token"> </span><span class="token" style="color: #032f62;">&#039;</span><span class="token" style="color: #032f62;">م</span><span class="token" style="color: #032f62;">&#039;</span><span class="token">;</span><span class="token">\n
</span></span></code></pre>
```