### PR TITLE
Simplify PhikiExtension instantiation by resolving Phiki inside register

### DIFF
--- a/src/Adapters/CommonMark/PhikiExtension.php
+++ b/src/Adapters/CommonMark/PhikiExtension.php
@@ -17,7 +17,6 @@ class PhikiExtension implements ConfigurableExtensionInterface
      */
     public function __construct(
         private string|array|Theme $theme = Theme::Nord,
-        private Phiki $phiki = new Phiki,
         private bool $withGutter = false,
     ) {}
 
@@ -38,7 +37,7 @@ class PhikiExtension implements ConfigurableExtensionInterface
 
         $environment->addRenderer(
             FencedCode::class,
-            new CodeBlockRenderer($theme, $this->phiki, $withGutter),
+            new CodeBlockRenderer($theme, resolve(Phiki::class), $withGutter),
             10,
         );
     }


### PR DESCRIPTION
Description
---
Currently, the `PhikiExtension` constructor accepts a `Phiki` instance. This requires users to explicitly resolve it from the container when registering the extension, which makes the usage example more verbose.

This PR simplifies the design by resolving Phiki inside the register method instead. As a result:

- The constructor only takes `$theme` and `$withGutter` arguments.
- The Phiki instance is resolved from the container during registration.
- The documentation example becomes shorter and easier to follow.

Before
---
```php
use Illuminate\Support\Str;
use Phiki\Adapters\CommonMark\PhikiExtension;
use Phiki\Theme\Theme;
use Phiki\Phiki;

Str::markdown($markdown, extensions: [
    new PhikiExtension(Theme::GithubLight, resolve(Phiki::class), withGutter: true),
]);
```

After
---
```php
use Illuminate\Support\Str;
use Phiki\Adapters\CommonMark\PhikiExtension;
use Phiki\Theme\Theme;

Str::markdown($markdown, extensions: [
    new PhikiExtension(Theme::GithubLight, withGutter: true),
]);
```

This keeps the core simpler and provides a cleaner developer experience while still resolving Phiki from the container at runtime.

Notes
---
- If this PR is merged, I will follow up with another PR to update the documentation accordingly.
- This change may be considered breaking, so it might be better suited for the next release.
- I'm also not fully certain whether resolving Phiki inside register is the best approach compared to resolving it once in the constructor; the constructor approach might have slight performance benefits. I'd appreciate feedback on this point.
- I'm also unsure whether the `PhikiExtension` class is used outside **Laravel**. If it's intended to be Laravel-only, then using the `resolve()` helper should be acceptable; otherwise, we may need to consider a framework-agnostic approach.

References
---
https://phiki.dev/laravel#enabling-the-gutter