### PR TITLE
Add NEON syntax highlighting support

### DIFF
--- a/meta/update-grammars-and-themes.js
+++ b/meta/update-grammars-and-themes.js
@@ -16,6 +16,10 @@ const grammars = [
     {
         name: "maml",
         scopeName: "source.maml",
+    },
+    {
+        name: "neon",
+        scopeName: "source.neon",
     }
 ]
 

--- a/resources/grammars/neon.json
+++ b/resources/grammars/neon.json
@@ -1,0 +1,265 @@
+{
+  "displayName": "NEON",
+  "fileTypes": [
+    "neon"
+  ],
+  "name": "neon",
+  "patterns": [
+    {
+      "begin": "(#)",
+      "end": "$",
+      "name": "comment.line.number-sign.neon",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment.neon"
+        }
+      }
+    },
+    {
+      "include": "#value"
+    }
+  ],
+  "repository": {
+    "value": {
+      "patterns": [
+        {
+          "include": "#constant"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#array"
+        },
+        {
+          "include": "#mapping"
+        },
+        {
+          "include": "#entity"
+        },
+        {
+          "include": "#service"
+        },
+        {
+          "include": "#variables"
+        }
+      ]
+    },
+    "array": {
+      "patterns": [
+        {
+          "begin": "\\[",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.array.begin.neon"
+            }
+          },
+          "end": "\\]",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.array.end.neon"
+            }
+          },
+          "name": "meta.structure.array.neon",
+          "patterns": [
+            {
+              "include": "#value"
+            },
+            {
+              "match": ",",
+              "name": "punctuation.separator.array.neon"
+            }
+          ]
+        },
+        {
+          "begin": "\\(",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.parameters.begin.neon"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.parameters.end.neon"
+            }
+          },
+          "name": "meta.structure.parameters.neon",
+          "patterns": [
+            {
+              "include": "#value"
+            },
+            {
+              "match": ",",
+              "name": "punctuation.separator.parameters.neon"
+            }
+          ]
+        }
+      ]
+    },
+    "entity": {
+      "patterns": [
+        {
+          "match": "([A-Z][a-zA-Z0-9_]*(?:\\\\[A-Z][a-zA-Z0-9_]*)*)(?=\\(|::|$|\\s)",
+          "name": "entity.name.class.neon"
+        },
+        {
+          "match": "(::)([a-zA-Z_][a-zA-Z0-9_]*)",
+          "captures": {
+            "1": {
+              "name": "punctuation.accessor.double-colon.neon"
+            },
+            "2": {
+              "name": "constant.other.class.neon"
+            }
+          }
+        }
+      ]
+    },
+    "mapping": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "entity.name.tag.neon"
+            },
+            "2": {
+              "name": "punctuation.separator.key-value.neon"
+            }
+          },
+          "match": "^(\\s*)([a-zA-Z_][a-zA-Z0-9._-]*)(:)(?=\\s|$)",
+          "name": "meta.mapping.key.neon"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "support.other.neon"
+            },
+            "2": {
+              "name": "punctuation.separator.key-value.neon"
+            }
+          },
+          "match": "^(\\s*)([a-zA-Z._-]*)(:)(?=\\s*\\S+)",
+          "name": "meta.mapping.neon"
+        }
+      ]
+    },
+    "constant": {
+      "patterns": [
+        {
+          "match": "\\b(true|false|yes|no|on|off|null|TRUE|FALSE|YES|NO|ON|OFF|NULL|True|False|Yes|No|On|Off|Null)\\b",
+          "name": "constant.language.neon"
+        },
+        {
+          "match": "\\b(\\d+)\\s*(days?|hours?|minutes?|seconds?|weeks?|months?|years?)\\b",
+          "name": "constant.other.timestamp.neon"
+        }
+      ]
+    },
+    "number": {
+      "patterns": [
+        {
+          "match": "\\b0[xX][0-9a-fA-F]+\\b",
+          "name": "constant.numeric.hex.neon"
+        },
+        {
+          "match": "\\b0[oO][0-7]+\\b",
+          "name": "constant.numeric.octal.neon"
+        },
+        {
+          "match": "\\b0[bB][01]+\\b",
+          "name": "constant.numeric.binary.neon"
+        },
+        {
+          "match": "\\b[+-]?(?:\\d+\\.?\\d*|\\.\\d+)(?:[eE][+-]?\\d+)?\\b",
+          "name": "constant.numeric.neon"
+        }
+      ]
+    },
+    "string": {
+      "patterns": [
+        {
+          "begin": "'''",
+          "end": "'''",
+          "name": "string.quoted.single.block.neon"
+        },
+        {
+          "begin": "\"\"\"",
+          "end": "\"\"\"",
+          "name": "string.quoted.double.block.neon",
+          "patterns": [
+            {
+              "include": "#string-escapes"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        },
+        {
+          "begin": "\"",
+          "end": "\"",
+          "name": "string.quoted.double.neon",
+          "patterns": [
+            {
+              "include": "#string-escapes"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        },
+        {
+          "begin": "'",
+          "end": "'",
+          "name": "string.quoted.single.neon",
+          "patterns": [
+            {
+              "match": "''",
+              "name": "constant.character.escape.neon"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        }
+      ]
+    },
+    "string-escapes": {
+      "patterns": [
+        {
+          "match": "\\\\[\\\\\"nrtfb0/]",
+          "name": "constant.character.escape.neon"
+        },
+        {
+          "match": "\\\\x[0-9a-fA-F]{2}",
+          "name": "constant.character.escape.hex.neon"
+        },
+        {
+          "match": "\\\\u[0-9a-fA-F]{4}",
+          "name": "constant.character.escape.unicode.neon"
+        }
+      ]
+    },
+    "variables": {
+      "patterns": [
+        {
+          "match": "(%[^%]*%)",
+          "name": "variable.other.neon"
+        }
+      ]
+    },
+    "service": {
+      "patterns": [
+        {
+          "match": "(@[a-zA-Z_][a-zA-Z0-9_\\\\.]*)",
+          "name": "variable.other.service.neon"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.neon"
+}

--- a/src/Grammar/Grammar.php
+++ b/src/Grammar/Grammar.php
@@ -54,7 +54,6 @@ enum Grammar: string
     case Dax = 'dax';
     case Desktop = 'desktop';
     case Diff = 'diff';
-    case Djot = 'djot';
     case Docker = 'docker';
     case Dotenv = 'dotenv';
     case DreamMaker = 'dream-maker';
@@ -136,7 +135,6 @@ enum Grammar: string
     case Mojo = 'mojo';
     case Move = 'move';
     case Narrat = 'narrat';
-    case Neon = 'neon';
     case Nextflow = 'nextflow';
     case Nginx = 'nginx';
     case Nim = 'nim';
@@ -233,7 +231,9 @@ enum Grammar: string
     case Yaml = 'yaml';
     case Zenscript = 'zenscript';
     case Zig = 'zig';
+    case Djot = 'djot';
     case Maml = 'maml';
+    case Neon = 'neon';
 
     public function aliases(): array
     {
@@ -283,7 +283,6 @@ enum Grammar: string
             self::Dax => [],
             self::Desktop => [],
             self::Diff => [],
-            self::Djot => ["dj"],
             self::Docker => ["dockerfile"],
             self::Dotenv => [],
             self::DreamMaker => [],
@@ -365,7 +364,6 @@ enum Grammar: string
             self::Mojo => [],
             self::Move => [],
             self::Narrat => ["nar"],
-            self::Neon => [],
             self::Nextflow => ["nf"],
             self::Nginx => [],
             self::Nim => [],
@@ -462,7 +460,9 @@ enum Grammar: string
             self::Yaml => ["yml"],
             self::Zenscript => [],
             self::Zig => [],
+            self::Djot => ["dj"],
             self::Maml => [],
+            self::Neon => [],
             self::Antlers => [],
             self::Txt => ['plaintext', 'text', 'plain'],
         };
@@ -516,7 +516,6 @@ enum Grammar: string
             self::Dax => 'source.dax',
             self::Desktop => 'source.desktop',
             self::Diff => 'source.diff',
-            self::Djot => 'text.djot',
             self::Docker => 'source.dockerfile',
             self::Dotenv => 'source.dotenv',
             self::DreamMaker => 'source.dm',
@@ -598,7 +597,6 @@ enum Grammar: string
             self::Mojo => 'source.mojo',
             self::Move => 'source.move',
             self::Narrat => 'source.narrat',
-            self::Neon => 'source.neon',
             self::Nextflow => 'source.nextflow',
             self::Nginx => 'source.nginx',
             self::Nim => 'source.nim',
@@ -695,7 +693,9 @@ enum Grammar: string
             self::Yaml => 'source.yaml',
             self::Zenscript => 'source.zenscript',
             self::Zig => 'source.zig',
+            self::Djot => 'text.djot',
             self::Maml => 'source.maml',
+            self::Neon => 'source.neon',
             self::Antlers => 'text.html.statamic',
             self::Txt => 'text.plain'
         };

--- a/src/Grammar/Grammar.php
+++ b/src/Grammar/Grammar.php
@@ -136,6 +136,7 @@ enum Grammar: string
     case Mojo = 'mojo';
     case Move = 'move';
     case Narrat = 'narrat';
+    case Neon = 'neon';
     case Nextflow = 'nextflow';
     case Nginx = 'nginx';
     case Nim = 'nim';
@@ -364,6 +365,7 @@ enum Grammar: string
             self::Mojo => [],
             self::Move => [],
             self::Narrat => ["nar"],
+            self::Neon => [],
             self::Nextflow => ["nf"],
             self::Nginx => [],
             self::Nim => [],
@@ -596,6 +598,7 @@ enum Grammar: string
             self::Mojo => 'source.mojo',
             self::Move => 'source.move',
             self::Narrat => 'source.narrat',
+            self::Neon => 'source.neon',
             self::Nextflow => 'source.nextflow',
             self::Nginx => 'source.nginx',
             self::Nim => 'source.nim',


### PR DESCRIPTION
## Summary

Adds syntax highlighting support for NEON files (`.neon`), a human-readable configuration format used by the Nette PHP framework.

This is commonly used for PHPStan configuration files (`phpstan.neon`).

## Changes

- Added `neon.json` grammar to `resources/grammars/`
- Added NEON entries to `Grammar.php` (enum case, alias, scopeName)

## Grammar Source

The TextMate grammar was originally sourced from the [VS-Code-Latte](https://github.com/Avaloran/VS-Code-Latte) extension (MIT license) and enhanced with additional patterns.

## Features

The grammar supports:
- Comments (`#`)
- Key-value mappings
- Service references (`@service`)
- Variable interpolation (`%variable%`)
- Strings (single, double, and triple-quoted)
- Escape sequences (`\n`, `\t`, `\xNN`, `\uNNNN`)
- Constants (true/false/null/yes/no/on/off)
- Numbers (decimal, hex, octal, binary, scientific notation)
- Time units (days, hours, minutes, etc.)
- Class/namespace references
- Arrays and parameter lists