### PR TITLE
Make league/commonmark an optional dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,11 @@
     ],
     "require": {
         "php": "^8.2",
-        "league/commonmark": "^2.5.3",
         "ext-mbstring": "*",
         "psr/simple-cache": "^3.0"
+    },
+    "suggest": {
+        "league/commonmark": "Required to use the CommonMark adapter (^2.5.3)"
     },
     "autoload": {
         "psr-4": {
@@ -35,7 +37,8 @@
         "phpstan/phpstan": "^2.0",
         "phpstan/extension-installer": "^1.4.3",
         "illuminate/support": "^11.45",
-        "orchestra/testbench": "^9.15"
+        "orchestra/testbench": "^9.15",
+        "league/commonmark": "^2.5.3"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
## Summary

- Moves `league/commonmark` from `require` to `suggest` in composer.json
- Adds `league/commonmark` to `require-dev` to keep tests working
- Allows users who use alternative markup parsers (like Djot) to install Phiki without pulling in CommonMark

Users who need the CommonMark adapter can simply run:
```
composer require league/commonmark
```

Fixes #132

Note: Since this is technically BC breaking, at least a minor release with a clear warning in the release notes would be good here. It could also wait until the next major of course.