### PR TITLE
Walk a cursor when recovering capture offsets

### DIFF
--- a/src/TextMate/PatternSearcher.php
+++ b/src/TextMate/PatternSearcher.php
@@ -81,8 +81,11 @@ class PatternSearcher
         // extract the relevant portion of the input string to reduce the
         // search grid for subsequent matches.
         $substr = mb_substr($lineText, $bestLocation, $bestLength);
+        $substrLength = mb_strlen($substr);
         $keyToIndexMap = array_flip(array_keys($bestMatches));
         $wellFormedMatches = [];
+        $previousStart = 0;
+        $previousEnd = 0;
 
         foreach ($bestMatches as $key => $match) {
             // The first match is the full match, so we can just use the start position.
@@ -103,9 +106,29 @@ class PatternSearcher
             }
 
             // For subsequent matches, we can use the reduced search grid to find the position
-            // of the match within the substring. We need to adjust the position based on the
-            // original input string's start position.
-            $pos = mb_strpos($substr, $match);
+            // of the match within the substring. Capture groups are numbered by opening
+            // parenthesis, so capture N + 1 can never start before capture N. Searching from
+            // a cursor instead of from the start keeps a capture that repeats earlier text -
+            // the closing delimiter of `(\*)([^*]+)(\*)`, for example - from resolving to the
+            // position of the opening one.
+            $pos = mb_strpos($substr, $match, min($previousStart, $substrLength));
+
+            // A candidate starting exactly where the previous capture did, but longer than it,
+            // cannot be nested inside it, so the real match has to be further along.
+            if ($pos === $previousStart && mb_strlen($match) > $previousEnd - $previousStart) {
+                $sibling = mb_strpos($substr, $match, min($previousEnd, $substrLength));
+
+                if ($sibling !== false) {
+                    $pos = $sibling;
+                }
+            }
+
+            if ($pos === false) {
+                $pos = (int) mb_strpos($substr, $match);
+            }
+
+            $previousStart = $pos;
+            $previousEnd = max($previousEnd, $pos + mb_strlen($match));
 
             // We can then store the value in the matches array with the adjusted position.
             $wellFormedMatches[$key] = [$match, $bestLocation + $pos];

--- a/tests/Unit/TokenizerTest.php
+++ b/tests/Unit/TokenizerTest.php
@@ -130,6 +130,64 @@ describe('match', function () {
             ],
         ]);
     });
+
+    it('can tokenize a match where a capture repeats the text of an earlier capture', function () {
+        $tokens = tokenize('*bold*', [
+            'scopeName' => 'source.test',
+            'patterns' => [
+                [
+                    'match' => '(\\*)([^*]+)(\\*)',
+                    'captures' => [
+                        '1' => [
+                            'name' => 'punctuation.definition.bold.test',
+                        ],
+                        '2' => [
+                            'name' => 'markup.bold.test',
+                        ],
+                        '3' => [
+                            'name' => 'punctuation.definition.bold.test',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        expect($tokens)->toEqualCanonicalizing([
+            [
+                new Token(['source.test', 'punctuation.definition.bold.test'], '*', 0, 1),
+                new Token(['source.test', 'markup.bold.test'], 'bold', 1, 5),
+                new Token(['source.test', 'punctuation.definition.bold.test'], '*', 5, 6),
+                new Token(['source.test'], "\n", 6, 7),
+            ],
+        ]);
+    });
+
+    it('can tokenize a match where a capture is nested inside the previous one', function () {
+        $tokens = tokenize('ab', [
+            'scopeName' => 'source.test',
+            'patterns' => [
+                [
+                    'match' => '((a)b)',
+                    'captures' => [
+                        '1' => [
+                            'name' => 'meta.outer.test',
+                        ],
+                        '2' => [
+                            'name' => 'meta.inner.test',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        expect($tokens)->toEqualCanonicalizing([
+            [
+                new Token(['source.test', 'meta.outer.test', 'meta.inner.test'], 'a', 0, 1),
+                new Token(['source.test', 'meta.outer.test'], 'b', 1, 2),
+                new Token(['source.test'], "\n", 2, 3),
+            ],
+        ]);
+    });
 });
 
 describe('begin/end', function () {


### PR DESCRIPTION
Fixes #141.

`mb_ereg_search_getregs()` gives capture texts but no offsets, so `PatternSearcher` re-derives each capture's position with `mb_strpos()` over the matched substring. Searching from the start means any capture whose text repeats earlier in the match resolves to the first occurrence.

The usual casualty is a closing delimiter identical to the opening one:

```json
{
  "match": "(\\*)([^*]+)(\\*)",
  "captures": {
    "1": { "name": "punctuation.definition.bold" },
    "2": { "name": "markup.bold" },
    "3": { "name": "punctuation.definition.bold" }
  }
}
```

On `*bold*` the closing `*` resolved to offset 0, `handleCaptures()` treated it as already consumed, and the token fell through with only the base scope:

```
"*"     -> [source, punctuation.definition.bold]
"bold"  -> [source, markup.bold]
"*"     -> [source]            <- scope lost
```

Every grammar using symmetric delimiters (markdown-family emphasis, quotes, fences) is affected.

### Fix

Capture groups are numbered by opening parenthesis, so capture N + 1 never starts before capture N. Walk a cursor instead of searching from 0. When a candidate starts exactly where the previous capture did but is longer than it, it cannot be nested inside it, so the search resumes past the previous capture's end.

Nested captures keep working (same start, shorter inner), symmetric siblings now resolve correctly. Both cases are covered by new tests in `TokenizerTest`.

### Known limits

Still a heuristic. Adjacent identical siblings such as `(a)(a)` over `aa` remain ambiguous from the strings alone, and captures inside a lookbehind can in principle start before the preceding capture. Exact offsets would need the oniguruma region API, which mbstring does not expose. I checked the lookbehind case (`(?:a)(b)(?<=([a])b)a` over `aba`) against both the old and new code and the tokenizer output is identical, so nothing regresses there, it is just as approximate as before.
